### PR TITLE
Support for arbitrary read names in simulators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.bina.varsim</groupId>
     <artifactId>varsim</artifactId>
-    <version>0.5.3</version>
+    <version>0.6</version>
     <packaging>jar</packaging>
 
     <name>varsim</name>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.github.samtools</groupId>
             <artifactId>htsjdk</artifactId>
-            <version>1.132</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>args4j</groupId>

--- a/src/main/java/com/bina/varsim/VarSim.java
+++ b/src/main/java/com/bina/varsim/VarSim.java
@@ -1,6 +1,7 @@
 package com.bina.varsim;
 
 import com.bina.varsim.fastqLiftover.FastqLiftOver;
+import com.bina.varsim.fastqLiftover.LongISLNDReadMapLiftOver;
 import com.bina.varsim.tools.VCFstats;
 import com.bina.varsim.tools.evaluation.JSONInserter;
 import com.bina.varsim.tools.evaluation.SAMcompare;
@@ -81,6 +82,9 @@ public class VarSim {
                 break;
             case "json_inserter":
                 new JSONInserter().run(pass_args);
+                break;
+            case "longislnd_liftover":
+                new LongISLNDReadMapLiftOver().run(pass_args);
                 break;
             default:
                 log.error("Unknown tool: " + args[0]);

--- a/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
@@ -1,15 +1,8 @@
 package com.bina.varsim.fastqLiftover;
 
-import com.bina.varsim.fastqLiftover.readers.ARTPairedFastqAlnReader;
-import com.bina.varsim.fastqLiftover.readers.DWGSIMPairedFastqReader;
-import com.bina.varsim.fastqLiftover.readers.PBSIMFastqReader;
-import com.bina.varsim.fastqLiftover.readers.PairedFastqReader;
-import com.bina.varsim.fastqLiftover.types.GenomeLocation;
 import com.bina.varsim.fastqLiftover.types.MapBlocks;
-import com.bina.varsim.fastqLiftover.types.SimulatedReadPair;
 import com.bina.varsim.readers.longislnd.LongISLNDReadAlignmentMap;
 import com.bina.varsim.types.ReadMapRecord;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.log4j.Logger;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -18,9 +11,7 @@ import org.kohsuke.args4j.Option;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.zip.Deflater;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class LongISLNDReadMapLiftOver {
@@ -28,8 +19,8 @@ public class LongISLNDReadMapLiftOver {
     String VERSION = "VarSim " + getClass().getPackage().getImplementationVersion();
     @Option(name = "-map", usage = "Map file", metaVar = "file")
     private File mapFile;
-    @Option(name = "-longislnd", usage = "Read map file from LongISLND", metaVar = "file")
-    private File longislnd;
+    @Option(name = "-longislnd", usage = "Read map files from LongISLND", metaVar = "file")
+    private Collection<File> longislnd;
     @Option(name = "-out", usage = "Output file", metaVar = "file")
     private File outFile;
     @Option(name = "-compress", usage = "Use GZIP compression")
@@ -80,8 +71,7 @@ public class LongISLNDReadMapLiftOver {
         log.info("Conversion took " + (System.currentTimeMillis() - tStart) / 1e3 + " seconds.");
     }
 
-    public void doLiftOver(final MapBlocks mapBlocks, final File longislnd, final PrintStream ps) throws IOException {
-        log.info("Reading read map file " + longislnd.getName());
+    public void doLiftOver(final MapBlocks mapBlocks, final Collection<File> longislnd, final PrintStream ps) throws IOException {
         final Collection<ReadMapRecord> readMapRecords = new LongISLNDReadAlignmentMap(longislnd).getReadAlignmentMap().values();
         int readCount = 0;
         for (final ReadMapRecord readMapRecord : readMapRecords) {

--- a/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
@@ -81,6 +81,7 @@ public class LongISLNDReadMapLiftOver {
     }
 
     public void doLiftOver(final MapBlocks mapBlocks, final File longislnd, final PrintStream ps) throws IOException {
+        log.info("Reading read map file " + longislnd.getName());
         final Collection<ReadMapRecord> readMapRecords = new LongISLNDReadAlignmentMap(longislnd).getReadAlignmentMap().values();
         int readCount = 0;
         for (final ReadMapRecord readMapRecord : readMapRecords) {

--- a/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
@@ -1,0 +1,96 @@
+package com.bina.varsim.fastqLiftover;
+
+import com.bina.varsim.fastqLiftover.readers.ARTPairedFastqAlnReader;
+import com.bina.varsim.fastqLiftover.readers.DWGSIMPairedFastqReader;
+import com.bina.varsim.fastqLiftover.readers.PBSIMFastqReader;
+import com.bina.varsim.fastqLiftover.readers.PairedFastqReader;
+import com.bina.varsim.fastqLiftover.types.GenomeLocation;
+import com.bina.varsim.fastqLiftover.types.MapBlocks;
+import com.bina.varsim.fastqLiftover.types.SimulatedReadPair;
+import com.bina.varsim.readers.longislnd.LongISLNDReadAlignmentMap;
+import com.bina.varsim.types.ReadMapRecord;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.log4j.Logger;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class LongISLNDReadMapLiftOver {
+    private final static Logger log = Logger.getLogger(LongISLNDReadMapLiftOver.class.getName());
+    String VERSION = "VarSim " + getClass().getPackage().getImplementationVersion();
+    @Option(name = "-map", usage = "Map file", metaVar = "file")
+    private File mapFile;
+    @Option(name = "-longislnd", usage = "Read map file from LongISLND", metaVar = "file")
+    private File longislnd;
+    @Option(name = "-out", usage = "Output file", metaVar = "file")
+    private File outFile;
+    @Option(name = "-compress", usage = "Use GZIP compression")
+    private boolean compress;
+
+    public static void main(String[] args) throws IOException {
+        new LongISLNDReadMapLiftOver().run(args);
+    }
+
+    public PrintStream getOutStream(final File outFile, boolean compress) throws IOException {
+        PrintStream ps = System.out;
+        if (outFile != null) {
+            if (compress) {
+                ps = new PrintStream(new GZIPOutputStream(new FileOutputStream(outFile)) {{
+                    def.setLevel(Deflater.BEST_SPEED);
+                }});
+            } else {
+                ps = new PrintStream(new BufferedOutputStream(new FileOutputStream(outFile)));
+            }
+        }
+        return ps;
+    }
+
+    public void run(String[] args) throws IOException {
+        CmdLineParser parser = new CmdLineParser(this);
+
+        // if you have a wider console, you could increase the value;
+        // here 80 is also the default
+        parser.setUsageWidth(80);
+
+        try {
+            parser.parseArgument(args);
+        } catch (CmdLineException e) {
+            System.err.println(VERSION);
+            System.err.println(e.getMessage());
+            System.err.println("java LongISLNDReadMapLiftOver [options...] arguments...");
+            // print the list of available options
+            parser.printUsage(System.err);
+            System.err.println();
+            return;
+        }
+
+        long tStart = System.currentTimeMillis();
+        MapBlocks mapBlocks = new MapBlocks(mapFile);
+
+        doLiftOver(mapBlocks, longislnd, getOutStream(outFile, compress));
+
+        log.info("Conversion took " + (System.currentTimeMillis() - tStart) / 1e3 + " seconds.");
+    }
+
+    public void doLiftOver(final MapBlocks mapBlocks, final File longislnd, final PrintStream ps) throws IOException {
+        final Collection<ReadMapRecord> readMapRecords = new LongISLNDReadAlignmentMap(longislnd).getReadAlignmentMap().values();
+        int readCount = 0;
+        for (final ReadMapRecord readMapRecord : readMapRecords) {
+            ps.println(mapBlocks.liftOverReadMapRecord(readMapRecord));
+            if ((readCount % 100000) == 0) {
+                log.info(readCount + " reads processed");
+            }
+            readCount++;
+        }
+        ps.close();
+        log.info(readCount + "reads processed");
+    }
+}

--- a/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/LongISLNDReadMapLiftOver.java
@@ -9,22 +9,24 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import java.io.*;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
 public class LongISLNDReadMapLiftOver {
     private final static Logger log = Logger.getLogger(LongISLNDReadMapLiftOver.class.getName());
     String VERSION = "VarSim " + getClass().getPackage().getImplementationVersion();
-    @Option(name = "-map", usage = "Map file", metaVar = "file")
+    @Option(name = "-map", usage = "Map file", metaVar = "file", required = true)
     private File mapFile;
-    @Option(name = "-longislnd", usage = "Read map files from LongISLND", metaVar = "file")
-    private Collection<File> longislnd;
-    @Option(name = "-out", usage = "Output file", metaVar = "file")
+    @Option(name = "-longislnd", usage = "Read map files from LongISLND", metaVar = "file", required = true)
+    private List<File> longislnd;
+    @Option(name = "-out", usage = "Output file", metaVar = "file", required = true)
     private File outFile;
     @Option(name = "-compress", usage = "Use GZIP compression")
     private boolean compress;
+    @Option(name = "-minIntervalLength", usage = "Minimum interval length in liftover")
+    private int minIntervalLength = MapBlocks.MIN_LENGTH_INTERVAL;
 
     public static void main(String[] args) throws IOException {
         new LongISLNDReadMapLiftOver().run(args);
@@ -75,7 +77,7 @@ public class LongISLNDReadMapLiftOver {
         final Collection<ReadMapRecord> readMapRecords = new LongISLNDReadAlignmentMap(longislnd).getReadAlignmentMap().values();
         int readCount = 0;
         for (final ReadMapRecord readMapRecord : readMapRecords) {
-            ps.println(mapBlocks.liftOverReadMapRecord(readMapRecord));
+            ps.println(mapBlocks.liftOverReadMapRecord(readMapRecord, minIntervalLength));
             if ((readCount % 100000) == 0) {
                 log.info(readCount + " reads processed");
             }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeInterval.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeInterval.java
@@ -1,0 +1,61 @@
+package com.bina.varsim.fastqLiftover.types;
+
+import htsjdk.tribble.annotation.Strand;
+
+public class GenomeInterval implements Comparable<GenomeInterval> {
+    protected String chromosome;
+    protected int start = -1;
+    protected int end = -1;
+    protected Strand strand = Strand.NONE;
+    protected MapBlock.BlockType feature = MapBlock.BlockType.UNKNOWN;
+
+    public GenomeInterval() {
+    }
+
+    public GenomeInterval(final String intervalString) {
+        final String fields[] = intervalString.split(",", -1);
+        chromosome = fields[0];
+        start = Integer.parseInt(fields[1]);
+        end = Integer.parseInt(fields[2]);
+        strand = Strand.valueOf(fields[3]);
+        feature = MapBlock.BlockType.valueOf(fields[4]);
+    }
+
+    public GenomeInterval(final String chromosome, final int start, final int end, final Strand strand, final MapBlock.BlockType feature) {
+        this.chromosome = chromosome;
+        this.start = start;
+        this.end = end;
+        this.strand = strand;
+        this.feature = feature;
+    }
+
+    public GenomeInterval(final String chromosome, final int start, final int end, final MapBlock.BlockType feature) {
+        this.chromosome = chromosome;
+        this.start = start;
+        this.end = end;
+        this.feature = feature;
+    }
+
+    @Override
+    public int compareTo(final GenomeInterval rhs) {
+        final int chrCmp = this.chromosome.compareTo(rhs.chromosome);
+        if (chrCmp != 0) {
+            return chrCmp;
+        }
+        if (start != rhs.start) {
+            return Integer.compare(start, rhs.start);
+        }
+        return Integer.compare(end, rhs.end);
+    }
+
+    public String toString() {
+        return chromosome + "," + Integer.toString(start) + "," + Integer.toString(end) + "," + strand.name() + "," + feature.name();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof GenomeInterval)) return false;
+        GenomeInterval rhs = (GenomeInterval) object;
+        return chromosome.equals(rhs.chromosome) && start == rhs.start && end == rhs.end && strand == rhs.strand && feature == rhs.feature;
+    }
+}

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeInterval.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeInterval.java
@@ -1,8 +1,12 @@
 package com.bina.varsim.fastqLiftover.types;
 
+import com.google.common.base.Joiner;
 import htsjdk.tribble.annotation.Strand;
 
 public class GenomeInterval implements Comparable<GenomeInterval> {
+    public static final String SEPARATOR = ",";
+    private static final Joiner joiner = Joiner.on(SEPARATOR).skipNulls();
+
     protected String chromosome;
     protected int start = -1;
     protected int end = -1;
@@ -13,7 +17,15 @@ public class GenomeInterval implements Comparable<GenomeInterval> {
     }
 
     public GenomeInterval(final String intervalString) {
-        final String fields[] = intervalString.split(",", -1);
+        final String fields[] = intervalString.split(SEPARATOR, -1);
+        chromosome = fields[0];
+        start = Integer.parseInt(fields[1]);
+        end = Integer.parseInt(fields[2]);
+        strand = Strand.valueOf(fields[3]);
+        feature = MapBlock.BlockType.valueOf(fields[4]);
+    }
+
+    public GenomeInterval(final String fields[]) {
         chromosome = fields[0];
         start = Integer.parseInt(fields[1]);
         end = Integer.parseInt(fields[2]);
@@ -49,7 +61,7 @@ public class GenomeInterval implements Comparable<GenomeInterval> {
     }
 
     public String toString() {
-        return chromosome + "," + Integer.toString(start) + "," + Integer.toString(end) + "," + strand.name() + "," + feature.name();
+        return joiner.join(chromosome, start, end, strand.name(), feature.name());
     }
 
     @Override
@@ -57,5 +69,25 @@ public class GenomeInterval implements Comparable<GenomeInterval> {
         if (!(object instanceof GenomeInterval)) return false;
         GenomeInterval rhs = (GenomeInterval) object;
         return chromosome.equals(rhs.chromosome) && start == rhs.start && end == rhs.end && strand == rhs.strand && feature == rhs.feature;
+    }
+
+    public String getChromosome() {
+        return chromosome;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public Strand getStrand() {
+        return strand;
+    }
+
+    public MapBlock.BlockType getFeature() {
+        return feature;
     }
 }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
@@ -1,13 +1,15 @@
 package com.bina.varsim.fastqLiftover.types;
 
 public class GenomeLocation implements Comparable<GenomeLocation> {
+    protected static final String SEPARATOR = "-";
+
     public String chromosome;
     public int location = 0;
     public int direction = 0;
     public MapBlock.BlockType feature;
 
     public GenomeLocation(final String locationString) {
-        final String fields[] = locationString.split("-", -1);
+        final String fields[] = locationString.split(SEPARATOR, -1);
         this.chromosome = fields[0];
         this.location = "".equals(fields[1]) ? 0 : Integer.parseInt(fields[1]);
         this.feature = MapBlock.BlockType.fromName(fields[2]);
@@ -50,7 +52,7 @@ public class GenomeLocation implements Comparable<GenomeLocation> {
     }
 
     public String toString() {
-        return chromosome + "-" + encodeInt(location) + "-" + (feature == MapBlock.BlockType.SEQ ? "" : feature.getShortName()) + ((direction == 0) ? "" : "-");
+        return chromosome + SEPARATOR + encodeInt(location) + SEPARATOR + (feature == MapBlock.BlockType.SEQ ? "" : feature.getShortName()) + ((direction == 0) ? "" : "-");
     }
 
     @Override

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
@@ -28,6 +28,14 @@ public class GenomeLocation implements Comparable<GenomeLocation> {
         this.feature = MapBlock.BlockType.SEQ;
     }
 
+    public boolean isClose(final String chromosome, final int location, final int wiggle) {
+        return this.chromosome.equals(chromosome) && Math.abs(this.location - location) <= wiggle;
+    }
+
+    public boolean isClose(final GenomeLocation other, final int wiggle) {
+        return chromosome.equals(other.chromosome) && Math.abs(location - other.location) <= wiggle;
+    }
+
     @Override
     public int compareTo(final GenomeLocation rhs) {
         final int chrCmp = this.chromosome.compareTo(rhs.chromosome);

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/GenomeLocation.java
@@ -1,5 +1,7 @@
 package com.bina.varsim.fastqLiftover.types;
 
+import htsjdk.tribble.annotation.Strand;
+
 public class GenomeLocation implements Comparable<GenomeLocation> {
     protected static final String SEPARATOR = "-";
 
@@ -28,6 +30,13 @@ public class GenomeLocation implements Comparable<GenomeLocation> {
         this.location = location;
         this.direction = direction;
         this.feature = MapBlock.BlockType.SEQ;
+    }
+
+    public GenomeLocation(final String chromosome, final int location, final Strand strand, final MapBlock.BlockType feature) {
+        this.chromosome = chromosome;
+        this.location = location;
+        direction = (strand == Strand.POSITIVE) ? 0 : 1;
+        this.feature = feature;
     }
 
     public boolean isClose(final String chromosome, final int location, final int wiggle) {

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
@@ -4,7 +4,7 @@ public class MapBlock implements Comparable<MapBlock> {
     public int size;
     public GenomeLocation srcLoc;
     public GenomeLocation dstLoc;
-    public BlockType blockType;
+    public BlockType blockType = BlockType.UNKNOWN;
     public int direction;
     public String name;
 
@@ -49,7 +49,7 @@ public class MapBlock implements Comparable<MapBlock> {
     }
 
     public enum BlockType {
-        SEQ("S", "Sequence", true), INS("I", "Insertion", false), DEL("D", "Deletion", false), INV("V", "Inversion", true), DUP_TANDEM("T", "Tandem_Duplication", true), UNKNOWN("U", "Unknown", true);
+        SEQ("S", "Sequence", true), INS("I", "Insertion", false), DEL("D", "Deletion", false), INV("V", "Inversion", true), DUP_TANDEM("T", "Tandem_Duplication", true), UNKNOWN("U", "Unknown", false);
 
         private final String shortName;
         private final String longName;

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
@@ -25,6 +25,10 @@ public class MapBlock implements Comparable<MapBlock> {
         this.direction = 0;
     }
 
+    public boolean isMappable() {
+        return blockType.isMappable();
+    }
+
     @Override
     public int compareTo(MapBlock rhs) {
         return srcLoc.location - rhs.srcLoc.location;

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlock.java
@@ -45,14 +45,16 @@ public class MapBlock implements Comparable<MapBlock> {
     }
 
     public enum BlockType {
-        SEQ("S", "Sequence"), INS("I", "Insertion"), DEL("D", "Deletion"), INV("V", "Inversion"), DUP_TANDEM("T", "Tandem_Duplication"), UNKNOWN("U", "Unknown");
+        SEQ("S", "Sequence", true), INS("I", "Insertion", false), DEL("D", "Deletion", false), INV("V", "Inversion", true), DUP_TANDEM("T", "Tandem_Duplication", true), UNKNOWN("U", "Unknown", true);
 
         private final String shortName;
         private final String longName;
+        private final boolean mappable;
 
-        BlockType(String shortName, String longName) {
+        BlockType(String shortName, String longName, final boolean mappable) {
             this.shortName = shortName;
             this.longName = longName;
+            this.mappable = mappable;
         }
 
         public static BlockType fromName(final String s) {
@@ -79,5 +81,7 @@ public class MapBlock implements Comparable<MapBlock> {
         public String getLongName() {
             return longName;
         }
+
+        public boolean isMappable() { return mappable; }
     }
 }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
@@ -2,6 +2,7 @@ package com.bina.varsim.fastqLiftover.types;
 
 import com.bina.varsim.fastqLiftover.readers.MapFileReader;
 import com.bina.varsim.types.ReadMapBlock;
+import com.bina.varsim.types.ReadMapRecord;
 import htsjdk.tribble.annotation.Strand;
 import org.apache.log4j.Logger;
 
@@ -140,5 +141,20 @@ public class MapBlocks {
         }
 
         return readMapBlocks;
+    }
+
+    public ReadMapRecord liftOverReadMapRecord(final ReadMapRecord readMapRecord) {
+        final List<Collection<ReadMapBlock>> liftedReadMaps = new ArrayList<>();
+        for (final Collection<ReadMapBlock> readMapBlocks : readMapRecord.getMultiReadMapBlocks()) {
+            final Collection<ReadMapBlock> liftedReadMapBlocks = new ArrayList<>();
+            for (final ReadMapBlock readMapBlock : readMapBlocks) {
+                final int offset = readMapBlock.getReadStart();
+                for (final ReadMapBlock liftedReadMapBlock : liftOverGenomeInterval(readMapBlock.getMapInterval())) {
+                    liftedReadMapBlocks.add(new ReadMapBlock(offset + liftedReadMapBlock.getReadStart(), offset + liftedReadMapBlock.getReadEnd(), liftedReadMapBlock.getMapInterval()));
+                }
+            }
+            liftedReadMaps.add(liftedReadMapBlocks);
+        }
+        return new ReadMapRecord(readMapRecord.getReadName(), liftedReadMaps);
     }
 }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
@@ -1,6 +1,8 @@
 package com.bina.varsim.fastqLiftover.types;
 
 import com.bina.varsim.fastqLiftover.readers.MapFileReader;
+import com.bina.varsim.types.ReadMapBlock;
+import htsjdk.tribble.annotation.Strand;
 import org.apache.log4j.Logger;
 
 import java.io.File;
@@ -84,5 +86,59 @@ public class MapBlocks {
             liftedLocs.add(liftedLoc);
         }
         return liftedLocs;
+    }
+
+    public Collection<ReadMapBlock> liftOverGenomeInterval(final GenomeInterval interval) {
+        final Collection<ReadMapBlock> readMapBlocks = new ArrayList<>();
+
+        final String chromosome = interval.chromosome;
+        final int start = interval.start;
+        final int end = interval.end;
+
+        final MapBlock keyStart = new MapBlock(new GenomeLocation(chromosome, start));
+        final MapBlock keyEnd = new MapBlock(new GenomeLocation(chromosome, end - 1));
+
+        if (!chrBlocks.containsKey(chromosome)) {
+            return readMapBlocks;
+        }
+
+        final NavigableSet<MapBlock> blocks = chrBlocks.get(chromosome);
+        final NavigableSet<MapBlock> subset = blocks.headSet(keyEnd, true).tailSet(blocks.headSet(keyStart, true).last(), true);
+
+        Iterator<MapBlock> it = subset.iterator();
+        log.trace("Going to lift over " + interval);
+
+        int intervalOffset = 0;
+        while (it.hasNext()) {
+            final MapBlock b = it.next();
+
+            int srcStart = Math.max(start, b.srcLoc.location);
+            int srcEnd = Math.min(end - 1, b.srcLoc.location + b.size - 1);
+            int lengthOfInterval = srcEnd - srcStart + 1;
+
+            log.trace("intervalStart = " + srcStart + " intervalEnd = " + srcEnd + " lengthOfInterval = " + lengthOfInterval);
+
+            if (lengthOfInterval < MIN_LENGTH_INTERVAL) {
+                log.trace("Skipping block " + b + " since the overlap is too small ( < " + MIN_LENGTH_INTERVAL + ")");
+            } else {
+                final GenomeInterval liftedInterval = new GenomeInterval();
+                liftedInterval.chromosome = b.dstLoc.chromosome;
+                liftedInterval.feature = b.blockType;
+                if (b.direction == 0) {
+                    liftedInterval.start = b.dstLoc.location + srcStart - b.srcLoc.location;
+                    liftedInterval.end = liftedInterval.start + lengthOfInterval;
+                    liftedInterval.strand = interval.strand;
+                } else {
+                    liftedInterval.start = b.dstLoc.location + (b.srcLoc.location + b.size - 1 - srcEnd);
+                    liftedInterval.end = liftedInterval.start + lengthOfInterval;
+                    liftedInterval.strand = interval.strand == Strand.POSITIVE ? Strand.NEGATIVE : Strand.POSITIVE;
+                }
+
+                readMapBlocks.add(new ReadMapBlock(intervalOffset, intervalOffset + lengthOfInterval, liftedInterval));
+            }
+            intervalOffset += lengthOfInterval;
+        }
+
+        return readMapBlocks;
     }
 }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/MapBlocks.java
@@ -89,7 +89,7 @@ public class MapBlocks {
         return liftedLocs;
     }
 
-    public Collection<ReadMapBlock> liftOverGenomeInterval(final GenomeInterval interval) {
+    public Collection<ReadMapBlock> liftOverGenomeInterval(final GenomeInterval interval, final int minIntervalLength) {
         final Collection<ReadMapBlock> readMapBlocks = new ArrayList<>();
 
         final String chromosome = interval.chromosome;
@@ -119,7 +119,7 @@ public class MapBlocks {
 
             log.trace("intervalStart = " + srcStart + " intervalEnd = " + srcEnd + " lengthOfInterval = " + lengthOfInterval);
 
-            if (lengthOfInterval < MIN_LENGTH_INTERVAL) {
+            if (lengthOfInterval < minIntervalLength) {
                 log.trace("Skipping block " + b + " since the overlap is too small ( < " + MIN_LENGTH_INTERVAL + ")");
             } else {
                 final GenomeInterval liftedInterval = new GenomeInterval();
@@ -143,18 +143,26 @@ public class MapBlocks {
         return readMapBlocks;
     }
 
-    public ReadMapRecord liftOverReadMapRecord(final ReadMapRecord readMapRecord) {
+    public Collection<ReadMapBlock> liftOverGenomeInterval(final GenomeInterval interval) {
+        return liftOverGenomeInterval(interval, MIN_LENGTH_INTERVAL);
+    }
+
+    public ReadMapRecord liftOverReadMapRecord(final ReadMapRecord readMapRecord, final int minIntervalLength) {
         final List<Collection<ReadMapBlock>> liftedReadMaps = new ArrayList<>();
         for (final Collection<ReadMapBlock> readMapBlocks : readMapRecord.getMultiReadMapBlocks()) {
             final Collection<ReadMapBlock> liftedReadMapBlocks = new ArrayList<>();
             for (final ReadMapBlock readMapBlock : readMapBlocks) {
                 final int offset = readMapBlock.getReadStart();
-                for (final ReadMapBlock liftedReadMapBlock : liftOverGenomeInterval(readMapBlock.getMapInterval())) {
+                for (final ReadMapBlock liftedReadMapBlock : liftOverGenomeInterval(readMapBlock.getMapInterval(), minIntervalLength)) {
                     liftedReadMapBlocks.add(new ReadMapBlock(offset + liftedReadMapBlock.getReadStart(), offset + liftedReadMapBlock.getReadEnd(), liftedReadMapBlock.getMapInterval()));
                 }
             }
             liftedReadMaps.add(liftedReadMapBlocks);
         }
         return new ReadMapRecord(readMapRecord.getReadName(), liftedReadMaps);
+    }
+
+    public ReadMapRecord liftOverReadMapRecord(final ReadMapRecord readMapRecord) {
+        return liftOverReadMapRecord(readMapRecord, MIN_LENGTH_INTERVAL);
     }
 }

--- a/src/main/java/com/bina/varsim/fastqLiftover/types/SimulatedRead.java
+++ b/src/main/java/com/bina/varsim/fastqLiftover/types/SimulatedRead.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class SimulatedRead {
@@ -134,5 +135,9 @@ public class SimulatedRead {
             name = getShortName();
         }
         return "@" + name + "\n" + sequence + "\n+\n" + quality;
+    }
+
+    public Collection<GenomeLocation> getLocs(int index) {
+        return (index == 0) ? locs1 : locs2;
     }
 }

--- a/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadAlignmentMap.java
+++ b/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadAlignmentMap.java
@@ -1,5 +1,6 @@
 package com.bina.varsim.readers.longislnd;
 
+import com.bina.varsim.types.ReadMapRecord;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.bed.BEDCodec;
@@ -16,7 +17,7 @@ import java.util.TreeMap;
  * Created by mohiyudm on 2/22/16.
  */
 public class LongISLNDReadAlignmentMap {
-    final protected Map<String, LongISLNDReadMapRecord> readAlignmentMap = new TreeMap<>();
+    final protected Map<String, ReadMapRecord> readAlignmentMap = new TreeMap<>();
 
     public LongISLNDReadAlignmentMap(final File readAlignmentMapFile) throws IOException {
         final AbstractFeatureReader<BEDFeature, LineIterator> featureReader = AbstractFeatureReader.getFeatureReader(readAlignmentMapFile.getName(), new BEDCodec(), false);
@@ -24,7 +25,7 @@ public class LongISLNDReadAlignmentMap {
             final CloseableTribbleIterator<BEDFeature> featureIterator = featureReader.iterator();
             while (featureIterator.hasNext()) {
                 final BEDFeature feature = featureIterator.next();
-                readAlignmentMap.put(feature.getName(), new LongISLNDReadMapRecord(feature));
+                readAlignmentMap.put(feature.getName(), new LongISLNDReadMapRecord(feature).toReadMapRecord());
             }
         } finally {
             featureReader.close();
@@ -33,9 +34,13 @@ public class LongISLNDReadAlignmentMap {
 
     public void writeReadMap(final File outFile) throws IOException {
         final PrintStream ps = new PrintStream(new BufferedOutputStream(new FileOutputStream(outFile)));
-        for (final Map.Entry<String, LongISLNDReadMapRecord> entry : readAlignmentMap.entrySet()) {
+        for (final Map.Entry<String, ReadMapRecord> entry : readAlignmentMap.entrySet()) {
             ps.println(entry.getValue());
         }
         ps.close();
+    }
+
+    public Map<String, ReadMapRecord> getReadAlignmentMap() {
+        return readAlignmentMap;
     }
 }

--- a/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadAlignmentMap.java
+++ b/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadAlignmentMap.java
@@ -6,29 +6,32 @@ import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.readers.LineIterator;
+import org.apache.log4j.Logger;
 
 import java.io.*;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Created by mohiyudm on 2/22/16.
  */
 public class LongISLNDReadAlignmentMap {
+    private final static Logger log = Logger.getLogger(LongISLNDReadAlignmentMap.class.getName());
+
     final protected Map<String, ReadMapRecord> readAlignmentMap = new TreeMap<>();
 
-    public LongISLNDReadAlignmentMap(final File readAlignmentMapFile) throws IOException {
-        final AbstractFeatureReader<BEDFeature, LineIterator> featureReader = AbstractFeatureReader.getFeatureReader(readAlignmentMapFile.getName(), new BEDCodec(), false);
-        try {
-            final CloseableTribbleIterator<BEDFeature> featureIterator = featureReader.iterator();
-            while (featureIterator.hasNext()) {
-                final BEDFeature feature = featureIterator.next();
-                readAlignmentMap.put(feature.getName(), new LongISLNDReadMapRecord(feature).toReadMapRecord());
+    public LongISLNDReadAlignmentMap(final Collection<File> readAlignmentMapFiles) throws IOException {
+        for (final File readAlignmentMapFile : readAlignmentMapFiles) {
+            log.info("Reading in read map from " + readAlignmentMapFile.getName());
+            final AbstractFeatureReader<BEDFeature, LineIterator> featureReader = AbstractFeatureReader.getFeatureReader(readAlignmentMapFile.getName(), new BEDCodec(), false);
+            try {
+                final CloseableTribbleIterator<BEDFeature> featureIterator = featureReader.iterator();
+                while (featureIterator.hasNext()) {
+                    final BEDFeature feature = featureIterator.next();
+                    readAlignmentMap.put(feature.getName(), new LongISLNDReadMapRecord(feature).toReadMapRecord());
+                }
+            } finally {
+                featureReader.close();
             }
-        } finally {
-            featureReader.close();
         }
     }
 

--- a/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadMapRecord.java
+++ b/src/main/java/com/bina/varsim/readers/longislnd/LongISLNDReadMapRecord.java
@@ -1,13 +1,16 @@
 package com.bina.varsim.readers.longislnd;
 
-import com.bina.varsim.fastqLiftover.types.GenomeLocation;
+import com.bina.varsim.fastqLiftover.types.GenomeInterval;
+import com.bina.varsim.fastqLiftover.types.MapBlock;
 import com.bina.varsim.fastqLiftover.types.MapBlocks;
+import com.bina.varsim.types.ReadMapBlock;
 import com.bina.varsim.types.ReadMapRecord;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.bed.BEDFeature;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+
 
 public class LongISLNDReadMapRecord {
     final protected String chromosome;
@@ -48,7 +51,7 @@ public class LongISLNDReadMapRecord {
         return strand;
     }
 
-    public ReadMapRecord toReadMapRecord(final MapBlocks mapBlocks) {
-        return new ReadMapRecord(readName, mapBlocks.liftOverInterval(chromosome, start, end, 0));
+    public ReadMapRecord toReadMapRecord() {
+        return new ReadMapRecord(readName, Collections.singletonList(new ReadMapBlock(0, end - start, new GenomeInterval(chromosome, start, end, strand, MapBlock.BlockType.UNKNOWN))));
     }
 }

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -220,9 +220,8 @@ public class SAMcompare {
                         validationStatus = true_unmapped ? StatsNamespace.TN : StatsNamespace.FN;
                     } else {
                         // check if the it mapped to the correct location
+                        boolean closeAln = false;
                         if (true_unmapped) {
-                            validationStatus = StatsNamespace.FP;
-
                             if (mapping_quality > mapqCutoff) {
                                 TUM_FP_writer.println(rec.getSAMString());
                             }
@@ -230,11 +229,9 @@ public class SAMcompare {
                             // Use unclipped location since the true locations are also unclipped
                             final GenomeLocation mappedLocation = new GenomeLocation(rec.getReferenceName(), rec.getUnclippedStart());
 
-                            boolean closeAln = false;
                             for (GenomeLocation loc : true_locs) {
                                 closeAln |= loc.feature.isMappable() && loc.isClose(mappedLocation, wiggle);
                             }
-                            validationStatus = closeAln ? StatsNamespace.TP : StatsNamespace.FP;
 
                             if (!closeAln) {
                                 if (mapping_quality > mapqCutoff) {
@@ -247,6 +244,7 @@ public class SAMcompare {
                                 }
                             }
                         }
+                        validationStatus = closeAln ? StatsNamespace.TP : StatsNamespace.FP;
                     }
                     output_blob.getStats().incStat(features, mapping_quality, validationStatus);
                 }

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -189,7 +189,7 @@ public class SAMcompare {
 
                     boolean true_unmapped;
 
-                    HashSet<String> features = new HashSet<>(4);
+                    Set<String> features = new HashSet<>(4);
                     features.add("All");
 
                     // determine if the read really should be unmapped
@@ -218,7 +218,6 @@ public class SAMcompare {
                     final StatsNamespace validationStatus;
                     if (unmapped) {
                         validationStatus = true_unmapped ? StatsNamespace.TN : StatsNamespace.FN;
-                        output_blob.getStats().incStat(features, mapping_quality, validationStatus);
                     } else {
                         // check if the it mapped to the correct location
                         if (true_unmapped) {

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -210,9 +210,7 @@ public class SAMcompare {
                             features.add(feat.getLongName());
 
                             // TODO check this with marghoob
-                            if (!(feat == BlockType.INS) && !(feat == BlockType.DEL)) {
-                                true_unmapped = false;
-                            }
+                            true_unmapped &= !feat.isMappable();
                         }
                     }
 
@@ -258,12 +256,7 @@ public class SAMcompare {
                             for (GenomeLocation loc : true_locs) {
                                 final BlockType feat = loc.feature;
 
-                                if ((feat == BlockType.INS) || (feat == BlockType.DEL)) {
-                                    continue;
-                                }
-
-                                if (chr.equals(loc.chromosome)) {
-
+                                if (feat.isMappable() && chr.equals(loc.chromosome)) {
                                     if (Math.abs(loc.location - pos) <= wiggle) {
                                         good_aln = true;
                                     }

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -179,6 +179,7 @@ public class SAMcompare {
                     // parse the name
                     // TODO need to check for errors here
                     int pair_idx = rec.getReadPairedFlag() ? getPairIdx(rec.getFirstOfPairFlag()): 0;
+                    log.trace("Getting true locations for read " + name);
                     final Collection<GenomeLocation> true_locs = readMap != null ? readMap.getReadMapRecord(name).getUnclippedStarts(pair_idx) : new SimulatedRead(name).getLocs(pair_idx);
 
                     if (!(intersector == null)) {

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -14,6 +14,7 @@ import com.bina.varsim.types.BedFile;
 import com.bina.varsim.types.ChrString;
 import com.bina.varsim.types.stats.MapRatioRecordSum;
 import com.bina.varsim.types.stats.StatsNamespace;
+import com.bina.varsim.util.ReadMap;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import htsjdk.samtools.SAMRecord;
@@ -148,6 +149,13 @@ public class SAMcompare {
                                 SamReaderFactory.Option.VALIDATE_CRC_CHECKSUMS)
                         .validationStringency(ValidationStringency.LENIENT);
 
+        ReadMap readMap = null;
+        try {
+            readMap = readMapFile != null ? new ReadMap(readMapFile) : null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
 
         for (String filename : bam_filename) {
             log.info("Reading file: " + filename);
@@ -171,7 +179,7 @@ public class SAMcompare {
                     // parse the name
                     // TODO need to check for errors here
                     int pair_idx = rec.getReadPairedFlag() ? getPairIdx(rec.getFirstOfPairFlag()): 0;
-                    Collection<GenomeLocation> true_locs = new SimulatedRead(name).getLocs(pair_idx);
+                    final Collection<GenomeLocation> true_locs = readMap != null ? readMap.getReadMapRecord(name).getUnclippedStarts(pair_idx) : new SimulatedRead(name).getLocs(pair_idx);
 
                     if (!(intersector == null)) {
                         boolean contained_in_bed = false;

--- a/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/SAMcompare.java
@@ -231,13 +231,13 @@ public class SAMcompare {
                             // Use unclipped location since the true locations are also unclipped
                             final GenomeLocation mappedLocation = new GenomeLocation(rec.getReferenceName(), rec.getUnclippedStart());
 
-                            boolean good_aln = false;
+                            boolean closeAln = false;
                             for (GenomeLocation loc : true_locs) {
-                                good_aln |= loc.feature.isMappable() && loc.isClose(mappedLocation, wiggle);
+                                closeAln |= loc.feature.isMappable() && loc.isClose(mappedLocation, wiggle);
                             }
-                            validationStatus = good_aln ? StatsNamespace.TP : StatsNamespace.FP;
+                            validationStatus = closeAln ? StatsNamespace.TP : StatsNamespace.FP;
 
-                            if (!good_aln) {
+                            if (!closeAln) {
                                 if (mapping_quality > mapqCutoff) {
                                     FP_writer.println(rec.getSAMString());
                                     for (final BlockType blockType : BlockType.values()) {

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -710,12 +710,7 @@ public class VCFcompare {
                     if (curr_var.isHom()) {
                         int max_true_len = comp.compare_variant(curr_var, geno.geno[0], validated_true);
 
-                        dual_idx idx;
-                        if (match_geno) {
-                            idx = comp.isHomMatch();
-                        } else {
-                            idx = comp.isMatch();
-                        }
+                        final dual_idx idx = match_geno ? comp.isHomMatch() : comp.isMatch();
 
                         if (idx.idx >= 0) {
                             // validated
@@ -746,12 +741,7 @@ public class VCFcompare {
                             }
                         }
 
-                        dual_idx idx;
-                        if (match_geno) {
-                            idx = comp.isHetMatch();
-                        } else {
-                            idx = comp.isMatch();
-                        }
+                        final dual_idx idx = match_geno ? comp.isHetMatch() : comp.isMatch();
 
                         if (idx.idx >= 0) {
                             validated_true.set(idx.idx);

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -98,7 +98,7 @@ public class VCFcompare {
     }
 
     // end = true will add the indel to the end, other wise it will add to start
-    private void add_indels(ArrayList<Variant> var_list, int[] diff, byte[] ref, byte[][] alt,
+    private void add_indels(List<Variant> var_list, int[] diff, byte[] ref, byte[][] alt,
                             Variant var, int curr_pos, boolean end) {
         // add insertions or deletions for complex variants
         if (diff[0] == diff[1] && diff[0] != 0) {
@@ -189,9 +189,9 @@ public class VCFcompare {
         }
     }
 
-    private ArrayList<Variant> convert_var_to_var_list(Variant var) {
-        ArrayList<Variant> var_list = convert_var_to_var_list(new Variant(var), false);
-        ArrayList<Variant> var_list_end = convert_var_to_var_list(new Variant(var), true);
+    private List<Variant> convert_var_to_var_list(Variant var) {
+        List<Variant> var_list = convert_var_to_var_list(new Variant(var), false);
+        List<Variant> var_list_end = convert_var_to_var_list(new Variant(var), true);
         if (var_list_end.size() < var_list.size()) {
             var_list = var_list_end;
         }
@@ -199,8 +199,8 @@ public class VCFcompare {
     }
 
     //if end = true, we add indels to the end
-    private ArrayList<Variant> convert_var_to_var_list(Variant var, boolean end) {
-        ArrayList<Variant> var_list = new ArrayList<>();
+    private List<Variant> convert_var_to_var_list(Variant var, boolean end) {
+        List<Variant> var_list = new ArrayList<>();
 
         //System.err.println("pat|mat: " + var.paternal() +"|"+ var.maternal());
         // if the variant is an MNP or SNP, break it dooooownnn
@@ -563,7 +563,7 @@ public class VCFcompare {
             // when comparing genotypes, we need to individually compare
             // to make sure they really overlap
 
-            ArrayList<Variant> var_list = convert_var_to_var_list(new Variant(var));
+            List<Variant> var_list = convert_var_to_var_list(new Variant(var));
 
             int total_len = 0;
             double max_len = 0;
@@ -680,7 +680,7 @@ public class VCFcompare {
                 VariantOverallType curr_var_type = var.getType();
 
                 // if called as complex variant convert to indel+snps
-                ArrayList<Variant> var_list = convert_var_to_var_list(new Variant(var));
+                List<Variant> var_list = convert_var_to_var_list(new Variant(var));
 
                 double total_len = 0;
                 double validated_len = 0;

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -572,10 +572,7 @@ public class VCFcompare {
             for (Variant curr_var : var_list) {
 
                 int curr_len = curr_var.maxLen();
-
-                if (curr_len > max_len) {
-                    max_len = curr_len;
-                }
+                max_len = Math.max(max_len, curr_len);
 
                 total_len += curr_len;
                 SimpleInterval1D curr_var_reg = null;
@@ -691,9 +688,7 @@ public class VCFcompare {
 
                 for (Variant curr_var : var_list) {
                     total_len += curr_var.maxLen();
-                    if (max_len < curr_var.maxLen()) {
-                        max_len = curr_var.maxLen();
-                    }
+                    max_len = Math.max(max_len, curr_var.maxLen());
                 }
 
                 // split up variants that are basically one big variant and one small one

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -734,10 +734,7 @@ public class VCFcompare {
                         for (int i = 0; i < 2; i++) {
                             byte allele = geno.geno[i];
                             if (allele > 0) {
-                                int len = comp.compare_variant(curr_var, allele, validated_true);
-                                if (len > max_true_len) {
-                                    max_true_len = len;
-                                }
+                                max_true_len = Math.max(comp.compare_variant(curr_var, allele, validated_true), max_true_len);
                             }
                         }
 

--- a/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
@@ -31,22 +31,22 @@ public class VCF2diploid {
 
     // arguments
     @Option(name = "-t", usage = "Gender of individual [MALE]")
-    GenderType _gender = GenderType.MALE;
+    GenderType gender = GenderType.MALE;
     @Option(name = "-chr", usage = "Comma separated list of reference genome files [Required]", metaVar = "FASTA_file", required = true)
-    List<String> _chrFiles = null;
+    List<String> chrfiles = null;
     @Option(name = "-vcf", usage = "Comma separated list of VCF files [Required]", metaVar = "VCF_file", required = true)
-    List<String> _vcfFiles = null;
+    List<String> vcfFiles = null;
     @Option(name = "-seed", usage = "Seed for random sampling [" + SEED_ARG + "]")
     long seed = 3333;
-    private Random _rand = null;
+    private Random rand = null;
     @Option(name = "-id", usage = "ID of individual in VCF file [Optional]")
-    private String _id = "varsim";
+    private String id = "varsim";
     @Option(name = "-pass", usage = "Only accept the PASS variants")
-    private boolean _pass = false;
-    private Map<ChrString, List<Variant>> _variants = new HashMap<>();
+    private boolean pass = false;
+    private Map<ChrString, List<Variant>> variants = new HashMap<>();
 
     public VCF2diploid() {
-        _rand = new Random(seed);
+        rand = new Random(seed);
     }
 
     /**
@@ -81,17 +81,17 @@ public class VCF2diploid {
             return;
         }
 
-        if (_chrFiles.size() == 0) {
+        if (chrfiles.size() == 0) {
             log.error("No chromosome file(s) is given!\n" + usage);
             return;
         }
 
-        if (_vcfFiles.size() == 0) {
+        if (vcfFiles.size() == 0) {
             log.error("No VCF file(s) is given!");
         }
 
-        for (String _vcfFile : _vcfFiles) {
-            VCFparser parser = new VCFparser(_vcfFile, _id, _pass, _rand);
+        for (String _vcfFile : vcfFiles) {
+            VCFparser parser = new VCFparser(_vcfFile, id, pass, rand);
             int n_ev = 0, var_nucs = 0;
             while (parser.hasMoreInput()) {
                 Variant var = parser.parseLine();
@@ -106,7 +106,7 @@ public class VCF2diploid {
 
                 if (var.maternal() < 0 || var.paternal() < 0) {
                     // randomize the genotype
-                    var.randomizeGenotype(_gender);
+                    var.randomizeGenotype(gender);
                 }
 
                 ChrString chr = var.getChr();
@@ -126,11 +126,11 @@ public class VCF2diploid {
     }
 
     private void addVariant(ChrString chr, Variant var) {
-        List<Variant> temp = _variants.get(chr);
+        List<Variant> temp = variants.get(chr);
         if (temp == null) {
             temp = new ArrayList<>();
             temp.add(var);
-            _variants.put(chr, temp);
+            variants.put(chr, temp);
         } else {
             temp.add(var);
         }
@@ -145,10 +145,7 @@ public class VCF2diploid {
         StringBuilder map_string = new StringBuilder();
 
         // This is the loop if chromosomes exist in separate files
-        SimpleReference all_seqs = new SimpleReference();
-        for (String _chrFile : _chrFiles) {
-            all_seqs.addReference(_chrFile);
-        }
+        SimpleReference all_seqs = new SimpleReference(chrfiles);
 
         // This is the loop through each chromosome
         for (ChrString chr : all_seqs.keySet()) {
@@ -159,12 +156,12 @@ public class VCF2diploid {
             boolean output_paternal = true;
             boolean output_maternal = true;
 
-            if (_gender == GenderType.FEMALE) {
+            if (gender == GenderType.FEMALE) {
                 if (chr.isY()) {
                     output_paternal = false;
                     output_maternal = false;
                 }
-            } else if (_gender == GenderType.MALE) {
+            } else if (gender == GenderType.MALE) {
                 // only male and female
                 if (chr.isX()) {
                     output_paternal = false;
@@ -183,10 +180,7 @@ public class VCF2diploid {
             }
 
             // this is the list of variants for the chromosome of question
-            List<Variant> varList = _variants.get(chr);
-            if (varList == null) {
-                varList = new ArrayList<>();
-            }
+            final List<Variant> varList = variants.containsKey(chr) ? variants.get(chr) : Collections.EMPTY_LIST;
 
             final List<Boolean> maternal_added_variants = new ArrayList<>();
             final List<Boolean> paternal_added_variants = new ArrayList<>();
@@ -303,7 +297,7 @@ public class VCF2diploid {
         }
 
         try {
-            FileWriter fw = new FileWriter(new File(_id + ".map"));
+            FileWriter fw = new FileWriter(new File(id + ".map"));
             BufferedWriter bw = new BufferedWriter(fw);
             bw.write(map_string.toString());
             bw.newLine();
@@ -713,7 +707,7 @@ public class VCF2diploid {
         writeMultiploid(Arrays.asList(maternal, paternal),
                 Arrays.asList(mat_ins_seq, pat_ins_seq),
                 Arrays.asList(maternalName(ref_seq.getName()), paternalName(ref_seq.getName())),
-                Arrays.asList(maternalName(ref_seq.getName() + "_" + _id) + ".fa", paternalName(ref_seq.getName() + "_" + _id) + ".fa"),
+                Arrays.asList(maternalName(ref_seq.getName() + "_" + id) + ".fa", paternalName(ref_seq.getName() + "_" + id) + ".fa"),
                 Arrays.asList(output_maternal, output_paternal));
     }
 
@@ -790,7 +784,7 @@ public class VCF2diploid {
                           final List<Boolean> paternal_added_variants,
                           final List<Boolean> maternal_added_variants,
                           final boolean output_paternal, final boolean output_maternal) {
-        String file_name = ref_seq.getName() + "_" + _id + ".vcf";
+        String file_name = ref_seq.getName() + "_" + id + ".vcf";
         log.info("Writing out the true variants for " + ref_seq.getName());
         try {
             FileWriter fw = new FileWriter(new File(file_name));
@@ -798,7 +792,7 @@ public class VCF2diploid {
 
             // write header
             bw.write("##fileformat=VCFv4.1\n" +
-                     "##reference=" + _chrFiles.get(0) + "\n" +
+                     "##reference=" + chrfiles.get(0) + "\n" +
                      "##INFO=<ID=SVLEN,Number=.,Type=Integer,Description=\"Length of variant\">\n" +
                      "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of structural variant\">\n" +
                      "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n" +
@@ -814,7 +808,7 @@ public class VCF2diploid {
                      "##ALT=<ID=CNV,Description=\"Copy number variable region\">\n" +
                      "##ALT=<ID=ITX,Description=\"Intra-chromosomal translocation\">\n" +
                      "##ALT=<ID=CTX,Description=\"Inter-chromosomal translocation\">\n" +
-                     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + _id + "\n");
+                     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + id + "\n");
 
             int num_vars = varList.size();
             final Map<Variant, Integer> indexMap = new HashMap<>();

--- a/src/main/java/com/bina/varsim/types/ReadMapBlock.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapBlock.java
@@ -2,11 +2,14 @@ package com.bina.varsim.types;
 
 import com.bina.varsim.fastqLiftover.types.GenomeInterval;
 import com.bina.varsim.fastqLiftover.types.GenomeLocation;
+import org.apache.log4j.Logger;
 
 /**
  * Created by mohiyudm on 2/25/16.
  */
 public class ReadMapBlock {
+    private final static Logger log = Logger.getLogger(ReadMapBlock.class.getName());
+
     public static final String SEPARATOR = GenomeInterval.SEPARATOR;
 
     protected int readStart;
@@ -25,6 +28,7 @@ public class ReadMapBlock {
     }
 
     public ReadMapBlock(final String s) {
+        log.trace("Parsing " + s);
         final String[] fields = s.split(SEPARATOR, -1);
         mapInterval = new GenomeInterval(fields);
         readStart = Integer.parseInt(fields[fields.length - 2]);

--- a/src/main/java/com/bina/varsim/types/ReadMapBlock.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapBlock.java
@@ -1,0 +1,48 @@
+package com.bina.varsim.types;
+
+import com.bina.varsim.fastqLiftover.types.GenomeInterval;
+
+/**
+ * Created by mohiyudm on 2/25/16.
+ */
+public class ReadMapBlock {
+    public static final String SEPARATOR = GenomeInterval.SEPARATOR;
+
+    protected int readStart;
+
+    protected int readEnd;
+
+    protected GenomeInterval mapInterval;
+
+    public ReadMapBlock() {
+    }
+
+    public ReadMapBlock(final int readStart, final int readEnd, final GenomeInterval mapInterval) {
+        this.readStart = readStart;
+        this.readEnd = readEnd;
+        this.mapInterval = mapInterval;
+    }
+
+    public ReadMapBlock(final String s) {
+        final String[] fields = s.split(SEPARATOR, -1);
+        mapInterval = new GenomeInterval(fields);
+        readStart = Integer.parseInt(fields[fields.length - 2]);
+        readEnd = Integer.parseInt(fields[fields.length - 1]);
+    }
+
+    public String toString() {
+        return mapInterval + SEPARATOR + readStart + SEPARATOR + readEnd;
+    }
+
+    public int getReadStart() {
+        return readStart;
+    }
+
+    public int getReadEnd() {
+        return readEnd;
+    }
+
+    public GenomeInterval getMapInterval() {
+        return mapInterval;
+    }
+}

--- a/src/main/java/com/bina/varsim/types/ReadMapBlock.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapBlock.java
@@ -1,6 +1,7 @@
 package com.bina.varsim.types;
 
 import com.bina.varsim.fastqLiftover.types.GenomeInterval;
+import com.bina.varsim.fastqLiftover.types.GenomeLocation;
 
 /**
  * Created by mohiyudm on 2/25/16.
@@ -44,5 +45,9 @@ public class ReadMapBlock {
 
     public GenomeInterval getMapInterval() {
         return mapInterval;
+    }
+
+    public GenomeLocation getUnclippedStart() {
+        return new GenomeLocation(mapInterval.getChromosome(), mapInterval.getStart() - readStart, mapInterval.getStrand(), mapInterval.getFeature());
     }
 }

--- a/src/main/java/com/bina/varsim/types/ReadMapRecord.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapRecord.java
@@ -1,38 +1,54 @@
 package com.bina.varsim.types;
 
-import com.bina.varsim.fastqLiftover.types.GenomeLocation;
+import com.bina.varsim.fastqLiftover.types.GenomeInterval;
 import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
-/**
- * Created by mohiyudm on 2/22/16.
- */
 public class ReadMapRecord {
+    public static final String COLUMN_SEPARATOR = "\t";
+    public static final String MAP_BLOCK_SEPARATOR = ":";
+    private static final Joiner joiner = Joiner.on(MAP_BLOCK_SEPARATOR).skipNulls();
+
     protected String readName;
-    private static final Joiner joiner = Joiner.on(",").skipNulls();
 
-    protected Collection<GenomeLocation> alignmentLocations;
+    protected List<Collection<ReadMapBlock>> multiReadMapBlocks;
 
-    public ReadMapRecord(final String readName, final Collection<GenomeLocation> alignmentLocations) {
+    public ReadMapRecord(final String readName, final List<Collection<ReadMapBlock>> multiReadMapBlocks) {
         this.readName = readName;
-        this.alignmentLocations = alignmentLocations;
+        this.multiReadMapBlocks = multiReadMapBlocks;
+    }
+
+    public ReadMapRecord(final String readName, final Collection<ReadMapBlock> ... multiReadMapBlocks) {
+        this.readName = readName;
+        this.multiReadMapBlocks = Arrays.asList(multiReadMapBlocks);
     }
 
     public ReadMapRecord(final String line) {
-        final String[] fields = line.split("\t");
+        final String[] fields = line.split(COLUMN_SEPARATOR);
         readName = fields[0];
-        alignmentLocations = new ArrayList<>();
-        final String locationStrings[] = fields[1].split(",", -1);
-        for (String locationString : locationStrings) {
-            if (!("".equals(locationString))) {
-                alignmentLocations.add(new GenomeLocation(locationString));
+        multiReadMapBlocks = new ArrayList<>();
+        for (int i = 1; i < fields.length; i++) {
+            final Collection<ReadMapBlock> readMapBlocks = new ArrayList<>();
+            final String readMapStrings[] = fields[i].split(MAP_BLOCK_SEPARATOR, -1);
+            for (final String readMapString : readMapStrings) {
+                readMapBlocks.add(new ReadMapBlock(readMapString));
             }
+            multiReadMapBlocks.add(readMapBlocks);
         }
     }
 
     public String toString() {
-        return readName + "\t" + joiner.join(alignmentLocations);
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(readName);
+        stringBuilder.append(COLUMN_SEPARATOR);
+        for (final Collection<ReadMapBlock> readMapBlocks : multiReadMapBlocks) {
+            stringBuilder.append(COLUMN_SEPARATOR);
+            stringBuilder.append(joiner.join(readMapBlocks));
+        }
+        return stringBuilder.toString();
     }
 }

--- a/src/main/java/com/bina/varsim/types/ReadMapRecord.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapRecord.java
@@ -3,6 +3,7 @@ package com.bina.varsim.types;
 import com.bina.varsim.fastqLiftover.types.GenomeInterval;
 import com.bina.varsim.fastqLiftover.types.GenomeLocation;
 import com.google.common.base.Joiner;
+import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,6 +11,8 @@ import java.util.Collection;
 import java.util.List;
 
 public class ReadMapRecord {
+    private final static Logger log = Logger.getLogger(ReadMapRecord.class.getName());
+
     public static final String COLUMN_SEPARATOR = "\t";
     public static final String MAP_BLOCK_SEPARATOR = ":";
     private static final Joiner joiner = Joiner.on(MAP_BLOCK_SEPARATOR).skipNulls();
@@ -32,12 +35,15 @@ public class ReadMapRecord {
     }
 
     public ReadMapRecord(final String line) {
+        log.trace("Parsing " + line);
         final String[] fields = line.trim().split(COLUMN_SEPARATOR);
         readName = fields[0];
+        log.trace("Name is " + readName);
         multiReadMapBlocks = new ArrayList<>();
         for (int i = 1; i < fields.length; i++) {
             final Collection<ReadMapBlock> readMapBlocks = new ArrayList<>();
-            final String readMapStrings[] = fields[i].split(MAP_BLOCK_SEPARATOR, -1);
+            log.trace("Will split " + fields[i]);
+            final String[] readMapStrings = fields[i].split(MAP_BLOCK_SEPARATOR, -1);
             for (final String readMapString : readMapStrings) {
                 readMapBlocks.add(new ReadMapBlock(readMapString));
             }
@@ -48,7 +54,6 @@ public class ReadMapRecord {
     public String toString() {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(readName);
-        stringBuilder.append(COLUMN_SEPARATOR);
         for (final Collection<ReadMapBlock> readMapBlocks : multiReadMapBlocks) {
             stringBuilder.append(COLUMN_SEPARATOR);
             stringBuilder.append(joiner.join(readMapBlocks));

--- a/src/main/java/com/bina/varsim/types/ReadMapRecord.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapRecord.java
@@ -1,6 +1,7 @@
 package com.bina.varsim.types;
 
 import com.bina.varsim.fastqLiftover.types.GenomeInterval;
+import com.bina.varsim.fastqLiftover.types.GenomeLocation;
 import com.google.common.base.Joiner;
 
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class ReadMapRecord {
     }
 
     public ReadMapRecord(final String line) {
-        final String[] fields = line.split(COLUMN_SEPARATOR);
+        final String[] fields = line.trim().split(COLUMN_SEPARATOR);
         readName = fields[0];
         multiReadMapBlocks = new ArrayList<>();
         for (int i = 1; i < fields.length; i++) {
@@ -69,5 +70,17 @@ public class ReadMapRecord {
 
     public void setMultiReadMapBlocks(List<Collection<ReadMapBlock>> multiReadMapBlocks) {
         this.multiReadMapBlocks = multiReadMapBlocks;
+    }
+
+    public Collection<ReadMapBlock> getReadMapBlocks(final int index) {
+        return multiReadMapBlocks.get(index);
+    }
+
+    public Collection<GenomeLocation> getUnclippedStarts(final int index) {
+        final Collection<GenomeLocation> locations = new ArrayList<>();
+        for (final ReadMapBlock readMapBlock : getReadMapBlocks(index)) {
+            locations.add(readMapBlock.getUnclippedStart());
+        }
+        return locations;
     }
 }

--- a/src/main/java/com/bina/varsim/types/ReadMapRecord.java
+++ b/src/main/java/com/bina/varsim/types/ReadMapRecord.java
@@ -17,6 +17,9 @@ public class ReadMapRecord {
 
     protected List<Collection<ReadMapBlock>> multiReadMapBlocks;
 
+    public ReadMapRecord() {
+    }
+
     public ReadMapRecord(final String readName, final List<Collection<ReadMapBlock>> multiReadMapBlocks) {
         this.readName = readName;
         this.multiReadMapBlocks = multiReadMapBlocks;
@@ -50,5 +53,21 @@ public class ReadMapRecord {
             stringBuilder.append(joiner.join(readMapBlocks));
         }
         return stringBuilder.toString();
+    }
+
+    public String getReadName() {
+        return readName;
+    }
+
+    public void setReadName(String readName) {
+        this.readName = readName;
+    }
+
+    public List<Collection<ReadMapBlock>> getMultiReadMapBlocks() {
+        return multiReadMapBlocks;
+    }
+
+    public void setMultiReadMapBlocks(List<Collection<ReadMapBlock>> multiReadMapBlocks) {
+        this.multiReadMapBlocks = multiReadMapBlocks;
     }
 }

--- a/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
+++ b/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
@@ -34,19 +34,6 @@ public class MapRatioRecordSum {
         all_data.incTP(val);
     }
 
-    public void incTP(String a, int val) {
-        RatioRecordSum count = data.get(a);
-        if (count != null) {
-            count.incTP(val);
-        } else {
-            RatioRecordSum contents = new RatioRecordSum();
-            contents.incTP(val);
-            data.put(a, contents);
-        }
-
-        all_data.incTP(val);
-    }
-
     public void incTN(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
@@ -57,19 +44,6 @@ public class MapRatioRecordSum {
                 contents.incTN(val);
                 data.put(key, contents);
             }
-        }
-
-        all_data.incTN(val);
-    }
-
-    public void incTN(String a, int val) {
-        RatioRecordSum count = data.get(a);
-        if (count != null) {
-            count.incTN(val);
-        } else {
-            RatioRecordSum contents = new RatioRecordSum();
-            contents.incTN(val);
-            data.put(a, contents);
         }
 
         all_data.incTN(val);
@@ -90,20 +64,6 @@ public class MapRatioRecordSum {
         all_data.incFP(val);
     }
 
-    public void incFP(String a, int val) {
-        RatioRecordSum count = data.get(a);
-        if (count != null) {
-            count.incFP(val);
-        } else {
-            RatioRecordSum contents = new RatioRecordSum();
-            contents.incFP(val);
-            data.put(a, contents);
-        }
-
-        all_data.incFP(val);
-    }
-
-
     public void incFN(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
@@ -119,19 +79,6 @@ public class MapRatioRecordSum {
         all_data.incFN(val);
     }
 
-    public void incFN(String a, int val) {
-        RatioRecordSum count = data.get(a);
-        if (count != null) {
-            count.incFN(val);
-        } else {
-            RatioRecordSum contents = new RatioRecordSum();
-            contents.incFN(val);
-            data.put(a, contents);
-        }
-
-        all_data.incFN(val);
-    }
-
     public void incT(Set<String> a) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
@@ -142,19 +89,6 @@ public class MapRatioRecordSum {
                 contents.incT();
                 data.put(key, contents);
             }
-        }
-
-        all_data.incT();
-    }
-
-    public void incT(String a) {
-        RatioRecordSum count = data.get(a);
-        if (count != null) {
-            count.incT();
-        } else {
-            RatioRecordSum contents = new RatioRecordSum();
-            contents.incT();
-            data.put(a, contents);
         }
 
         all_data.incT();

--- a/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
+++ b/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
@@ -19,6 +19,27 @@ public class MapRatioRecordSum {
         all_data = new RatioRecordSum();
     }
 
+    public void incStat(final Set<String> a, final int val, final StatsNamespace stat) {
+        switch(stat) {
+            case TP:
+                incTP(a, val);
+                break;
+            case FP:
+                incFP(a, val);
+                break;
+            case TN:
+                incTN(a, val);
+                break;
+            case FN:
+                incFN(a, val);
+                break;
+            case T:
+                incT(a);
+                break;
+            default:
+        }
+    }
+
     public void incTP(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);

--- a/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
+++ b/src/main/java/com/bina/varsim/types/stats/MapRatioRecordSum.java
@@ -2,6 +2,7 @@ package com.bina.varsim.types.stats;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -18,7 +19,7 @@ public class MapRatioRecordSum {
         all_data = new RatioRecordSum();
     }
 
-    public void incTP(HashSet<String> a, int val) {
+    public void incTP(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
             if (count != null) {
@@ -46,7 +47,7 @@ public class MapRatioRecordSum {
         all_data.incTP(val);
     }
 
-    public void incTN(HashSet<String> a, int val) {
+    public void incTN(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
             if (count != null) {
@@ -74,7 +75,7 @@ public class MapRatioRecordSum {
         all_data.incTN(val);
     }
 
-    public void incFP(HashSet<String> a, int val) {
+    public void incFP(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
             if (count != null) {
@@ -103,7 +104,7 @@ public class MapRatioRecordSum {
     }
 
 
-    public void incFN(HashSet<String> a, int val) {
+    public void incFN(Set<String> a, int val) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
             if (count != null) {
@@ -131,7 +132,7 @@ public class MapRatioRecordSum {
         all_data.incFN(val);
     }
 
-    public void incT(HashSet<String> a) {
+    public void incT(Set<String> a) {
         for (String key : a) {
             RatioRecordSum count = data.get(key);
             if (count != null) {

--- a/src/main/java/com/bina/varsim/util/ReadMap.java
+++ b/src/main/java/com/bina/varsim/util/ReadMap.java
@@ -1,0 +1,34 @@
+package com.bina.varsim.util;
+
+import com.bina.varsim.types.ReadMapRecord;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Created by mohiyudm on 2/29/16.
+ */
+public class ReadMap extends GzFileParser<ReadMapRecord>{
+    protected Map<String, ReadMapRecord> readMap = new HashMap<>();
+
+    public ReadMap(final File file) throws IOException {
+        _br = new BufferedReader(new InputStreamReader(decompressStream(file.getName())));
+        while (hasMoreInput()) {
+            final ReadMapRecord record = parseLine();
+            readMap.put(record.getReadName(), record);
+        }
+    }
+
+    public ReadMapRecord parseLine() {
+        return hasMoreInput() ? new ReadMapRecord(_line.trim()) : null;
+    }
+
+    public ReadMapRecord getReadMapRecord(final String readName) {
+        return readMap.containsKey(readName) ? readMap.get(readName) : null;
+    }
+}

--- a/src/main/java/com/bina/varsim/util/ReadMap.java
+++ b/src/main/java/com/bina/varsim/util/ReadMap.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Created by mohiyudm on 2/29/16.

--- a/src/main/java/com/bina/varsim/util/ReadMap.java
+++ b/src/main/java/com/bina/varsim/util/ReadMap.java
@@ -1,6 +1,7 @@
 package com.bina.varsim.util;
 
 import com.bina.varsim.types.ReadMapRecord;
+import org.apache.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -14,14 +15,23 @@ import java.util.TreeMap;
  * Created by mohiyudm on 2/29/16.
  */
 public class ReadMap extends GzFileParser<ReadMapRecord>{
+    private final static Logger log = Logger.getLogger(ReadMap.class.getName());
+
     protected Map<String, ReadMapRecord> readMap = new HashMap<>();
 
     public ReadMap(final File file) throws IOException {
+        log.info("Loading read alignment map from " + file.getName());
         _br = new BufferedReader(new InputStreamReader(decompressStream(file.getName())));
         while (hasMoreInput()) {
+            readLine();
+            log.trace("Parsing line " + _line);
+            if (_line == null || _line.trim().isEmpty()) {
+                break;
+            }
             final ReadMapRecord record = parseLine();
             readMap.put(record.getReadName(), record);
         }
+        log.info("Done loading read alignment map");
     }
 
     public ReadMapRecord parseLine() {

--- a/src/main/java/com/bina/varsim/util/SimpleReference.java
+++ b/src/main/java/com/bina/varsim/util/SimpleReference.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -21,7 +22,7 @@ public class SimpleReference {
     private final static Logger log = Logger.getLogger(SimpleReference.class.getName());
 
     // chr_idx -> reference_string
-    private final HashMap<ChrString, Sequence> data;
+    private final Map<ChrString, Sequence> data;
 
     public SimpleReference() {
         data = new HashMap<>();

--- a/src/main/java/com/bina/varsim/util/SimpleReference.java
+++ b/src/main/java/com/bina/varsim/util/SimpleReference.java
@@ -6,6 +6,7 @@ package com.bina.varsim.util;
  * @author johnmu
  */
 
+import com.bina.varsim.fastqLiftover.types.SimulatedRead;
 import com.bina.varsim.types.ChrString;
 import com.bina.varsim.types.Sequence;
 import htsjdk.samtools.reference.FastaSequenceFile;
@@ -13,6 +14,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import org.apache.log4j.Logger;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -22,18 +24,24 @@ public class SimpleReference {
     private final static Logger log = Logger.getLogger(SimpleReference.class.getName());
 
     // chr_idx -> reference_string
-    private final Map<ChrString, Sequence> data;
+    private final Map<ChrString, Sequence> data = new HashMap<>();
 
     public SimpleReference() {
-        data = new HashMap<>();
     }
 
     /**
      * @param filename FASTA file, should include the fai index
      */
     public SimpleReference(String filename) {
-        this();
         addReference(filename);
+    }
+
+    public SimpleReference(final Collection<String> filenames) {
+        if (filenames != null) {
+            for (final String filename : filenames) {
+                addReference(filename);
+            }
+        }
     }
 
     /**

--- a/src/test/java/com/bina/varsim/fastqLiftover/GenomeIntervalTest.java
+++ b/src/test/java/com/bina/varsim/fastqLiftover/GenomeIntervalTest.java
@@ -1,0 +1,42 @@
+package com.bina.varsim.fastqLiftover;
+
+import com.bina.varsim.fastqLiftover.types.GenomeInterval;
+import com.bina.varsim.fastqLiftover.types.GenomeLocation;
+import com.bina.varsim.fastqLiftover.types.MapBlock;
+import htsjdk.tribble.annotation.Strand;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for GenomeLocation
+ */
+public class GenomeIntervalTest
+        extends TestCase {
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public GenomeIntervalTest(String testName) {
+        super(testName);
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite() {
+        return new TestSuite(GenomeIntervalTest.class);
+    }
+
+    public void testGenomeLocationSimple() {
+        final String intervalString = "1,100,200,POSITIVE,INV,";
+        final GenomeInterval genomeInterval = new GenomeInterval(intervalString);
+
+        assertEquals("1", genomeInterval.getChromosome());
+        assertEquals(100, genomeInterval.getStart());
+        assertEquals(200, genomeInterval.getEnd());
+        assertEquals(Strand.POSITIVE, genomeInterval.getStrand());
+        assertEquals(MapBlock.BlockType.INV, genomeInterval.getFeature());
+    }
+}

--- a/varsim.iml
+++ b/varsim.iml
@@ -13,10 +13,15 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: com.github.samtools:htsjdk:1.132" level="project" />
+    <orderEntry type="library" name="Maven: com.github.samtools:htsjdk:2.1.0" level="project" />
+    <orderEntry type="library" name="Maven: gov.nih.nlm.ncbi:ngs-java:1.2.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-jexl:2.1.1" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.1" level="project" />
     <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.0.3-rc3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.tukaani:xz:1.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.ant:ant:1.8.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.ant:ant-launcher:1.8.2" level="project" />
     <orderEntry type="library" name="Maven: args4j:args4j:2.0.26" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:17.0" level="project" />
     <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />

--- a/varsim.py
+++ b/varsim.py
@@ -13,6 +13,7 @@ import glob
 from distutils.version import LooseVersion
 from multiprocessing import Process
 
+VERSION = "0.6"
 
 def get_contigs_list(reference):
     with open("%s.fai" % (reference)) as fai_file:
@@ -74,6 +75,7 @@ main_parser.add_argument("--vcfs", metavar="VCF",
 main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force output bases to be only ACTGN")
 main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants for simulation")
 main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files after simulation")
+main_parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
 
 pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
 pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true",

--- a/varsim.py
+++ b/varsim.py
@@ -222,7 +222,7 @@ def check_executable(fpath):
 jv = filter(lambda x: x.startswith("java version"), subprocess.check_output("java -version", stderr=subprocess.STDOUT, shell=True).split("\n"))[0].split()[2].replace("\"", "")
 if LooseVersion(jv) < LooseVersion("1.8"):
     logger.error("VarSim requires Java 1.8 to be on the path.")
-    sys.exit(1)
+    raise EnvironmentError("VarSim requires Java 1.8 to be on the path")
 
 # Make sure we can actually execute the executable
 if not args.disable_sim:

--- a/varsim.py
+++ b/varsim.py
@@ -75,7 +75,7 @@ main_parser.add_argument("--vcfs", metavar="VCF",
 main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force output bases to be only ACTGN")
 main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants for simulation")
 main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files after simulation")
-main_parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
+main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
 
 pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
 pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true",

--- a/varsim.py
+++ b/varsim.py
@@ -475,7 +475,7 @@ if not args.disable_sim:
             processes.append(pbsim_p)
             logger.info("Executing command " + pbsim_command + " with pid " + str(pbsim_p.pid))
     elif args.simulator == "longislnd":
-        longislnd_command = [args.simulator_executable, args.longislnd_options, "--coverage", str(args.total_coverage), "--out", os.path.join(args.out_dir, "longislnd_sim"), "--fasta", merged_reference]
+        longislnd_command = [args.simulator_executable.name, args.longislnd_options, "--coverage", str(args.total_coverage), "--out", os.path.join(args.out_dir, "longislnd_sim"), "--fasta", merged_reference]
         longislnd_command = " ".join(longislnd_command)
         longislnd_stdout = open(os.path.join(args.log_dir, "longislnd.out"), "w")
         longislnd_stderr = open(os.path.join(args.log_dir, "longislnd.err"), "w")

--- a/varsim.py
+++ b/varsim.py
@@ -10,6 +10,7 @@ import time
 import signal
 import itertools
 import glob
+from distutils.version import LooseVersion
 from multiprocessing import Process
 
 
@@ -217,7 +218,11 @@ def check_executable(fpath):
 
 # ####### END Some functions here ##########
 
-
+# Check java version to make sure it is Java 8
+jv = filter(lambda x: x.startswith("java version"), subprocess.check_output("java -version", stderr=subprocess.STDOUT, shell=True).split("\n"))[0].split()[2].replace("\"", "")
+if LooseVersion(jv) < LooseVersion("1.8"):
+    logger.error("VarSim requires Java 1.8 to be on the path.")
+    sys.exit(1)
 
 # Make sure we can actually execute the executable
 if not args.disable_sim:

--- a/varsim.py
+++ b/varsim.py
@@ -27,150 +27,6 @@ def check_java():
         logger.error("VarSim requires Java 1.8 to be on the path.")
         raise EnvironmentError("VarSim requires Java 1.8 to be on the path")
 
-
-my_dir = os.path.dirname(os.path.realpath(__file__))
-
-default_varsim_jar = os.path.join(my_dir, "VarSim.jar")
-
-require_varsim_jar = not os.path.isfile(default_varsim_jar)
-
-if not os.path.isfile(default_varsim_jar): require_varsim_jar = None
-
-main_parser = argparse.ArgumentParser(description="VarSim: A high-fidelity simulation validation framework",
-                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-main_parser.add_argument("--out_dir", metavar="DIR",
-                         help="Output directory for the simulated genome, reads and variants", required=False,
-                         default="out")
-main_parser.add_argument("--work_dir", metavar="DIR", help="Work directory, currently not used", required=False,
-                         default="work")
-main_parser.add_argument("--log_dir", metavar="DIR", help="Log files of all steps are kept here", required=False,
-                         default="log")
-main_parser.add_argument("--reference", metavar="FASTA", help="Reference genome that variants will be inserted into",
-                         required=True, type=file)
-main_parser.add_argument("--seed", metavar="seed", help="Random number seed for reproducibility", type=int, default=0)
-main_parser.add_argument("--sex", metavar="Sex", help="Sex of the person (MALE/FEMALE)", required=False, type=str,
-                         choices=["MALE", "FEMALE"], default="MALE")
-main_parser.add_argument("--id", metavar="ID", help="Sample ID to be put in output VCF file", required=True)
-main_parser.add_argument("--simulator", metavar="SIMULATOR", help="Read simulator to use", required=False, type=str,
-                         choices=["art", "dwgsim", "longislnd"], default="art")
-main_parser.add_argument("--simulator_executable", metavar="PATH",
-                         help="Path to the executable of the read simulator chosen"
-                         , required=True, type=file)
-main_parser.add_argument("--varsim_jar", metavar="PATH", help="Path to VarSim.jar", type=file,
-                         default=default_varsim_jar,
-                         required=require_varsim_jar)
-main_parser.add_argument("--read_length", metavar="LENGTH", help="Length of read to simulate", default=100, type=int)
-main_parser.add_argument("--nlanes", metavar="INTEGER",
-                         help="Number of lanes to generate, coverage will be divided evenly over the lanes. Simulation is parallized over lanes. Each lane will have its own pair of files",
-                         default=1, type=int)
-main_parser.add_argument("--total_coverage", metavar="FLOAT", help="Total coverage to simulate", default=1.0,
-                         type=float)
-main_parser.add_argument("--mean_fragment_size", metavar="INT", help="Mean fragment size to simulate", default=350,
-                         type=int)
-main_parser.add_argument("--sd_fragment_size", metavar="INT", help="Standard deviation of fragment size to simulate",
-                         default=50, type=int)
-main_parser.add_argument("--vcfs", metavar="VCF",
-                         help="Addtional list of VCFs to insert into genome, priority is lowest ... highest", nargs="+",
-                         default=[])
-main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force output bases to be only ACTGN")
-main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants for simulation")
-main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files after simulation")
-main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
-
-pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
-pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true",
-                                    help="Disable sampling from the provided small variant VCF")
-pipeline_control_group.add_argument("--disable_rand_dgv", action="store_true",
-                                    help="Disable sampline from the provided DGV file")
-pipeline_control_group.add_argument("--disable_vcf2diploid", action="store_true",
-                                    help="Disable diploid genome simulation")
-pipeline_control_group.add_argument("--disable_sim", action="store_true", help="Disable read simulation")
-
-# RandVCF2VCF seed num_SNP num_INS num_DEL num_MNP num_COMPLEX percent_novel min_length_lim max_length_lim reference_file file.vcf
-rand_vcf_group = main_parser.add_argument_group("Small variant simulation options")
-rand_vcf_group.add_argument("--vc_num_snp", metavar="INTEGER", help="Number of SNPs to sample from small variant VCF",
-                            default=0, type=int)
-rand_vcf_group.add_argument("--vc_num_ins", metavar="INTEGER",
-                            help="Number of insertions to sample from small variant VCF", default=0, type=int)
-rand_vcf_group.add_argument("--vc_num_del", metavar="INTEGER",
-                            help="Number of deletions to sample from small variant VCF", default=0, type=int)
-rand_vcf_group.add_argument("--vc_num_mnp", metavar="INTEGER", help="Number of MNPs to sample from small variant VCF",
-                            default=0, type=int)
-rand_vcf_group.add_argument("--vc_num_complex", metavar="INTEGER",
-                            help="Number of complex variants to sample from small variant VCF", default=0,
-                            type=int)
-rand_vcf_group.add_argument("--vc_percent_novel", metavar="FLOAT",
-                            help="Percent variants sampled from small variant VCF that will be moved to novel positions",
-                            default=0, type=float)
-rand_vcf_group.add_argument("--vc_min_length_lim", metavar="INTEGER",
-                            help="Min length of small variant to accept [inclusive]", default=0, type=int)
-rand_vcf_group.add_argument("--vc_max_length_lim", metavar="INTEGER",
-                            help="Max length of small variant to accept [inclusive]", default=99,
-                            type=int)
-rand_vcf_group.add_argument("--vc_in_vcf", metavar="VCF", help="Input small variant VCF, usually dbSNP", type=file,
-                            required=False)
-rand_vcf_group.add_argument("--vc_prop_het", metavar="FLOAT", help="Proportion of heterozygous small variants",
-                            default=0.6,
-                            type=float)
-
-# RandDGV2VCF seed num_INS num_DEL num_DUP num_INV percent_novel min_length_lim max_length_lim reference_file insert_seq.txt dgv_file.txt
-rand_dgv_group = main_parser.add_argument_group("Structural variant simulation options")
-rand_dgv_group.add_argument("--sv_num_ins", metavar="INTEGER", help="Number of insertions to sample from DGV",
-                            default=20, type=int)
-rand_dgv_group.add_argument("--sv_num_del", metavar="INTEGER", help="Number of deletions to sample from DGV",
-                            default=20, type=int)
-rand_dgv_group.add_argument("--sv_num_dup", metavar="INTEGER", help="Number of duplications to sample from DGV",
-                            default=20, type=int)
-rand_dgv_group.add_argument("--sv_num_inv", metavar="INTEGER", help="Number of inversions to sample from DGV",
-                            default=20, type=int)
-rand_dgv_group.add_argument("--sv_percent_novel", metavar="FLOAT",
-                            help="Percent variants sampled from DGV that will be moved to novel positions", default=0,
-                            type=float)
-rand_dgv_group.add_argument("--sv_min_length_lim", metavar="min_length_lim",
-                            help="Min length of structural variant to accept [inclusive]", default=100,
-                            type=int)
-rand_dgv_group.add_argument("--sv_max_length_lim", metavar="max_length_lim",
-                            help="Max length of structural variant to accept [inclusive]", default=1000000,
-                            type=int)
-rand_dgv_group.add_argument("--sv_insert_seq", metavar="FILE",
-                            help="Path to file containing concatenation of real insertion sequences", type=file,
-                            required=False)
-rand_dgv_group.add_argument("--sv_dgv", metavar="DGV_FILE", help="DGV file containing structural variants", type=file,
-                            required=False)
-
-dwgsim_group = main_parser.add_argument_group("DWGSIM options")
-dwgsim_group.add_argument("--dwgsim_start_e", metavar="first_base_error_rate", help="Error rate on the first base",
-                          default=0.0001, type=float)
-dwgsim_group.add_argument("--dwgsim_end_e", metavar="last_base_error_rate", help="Error rate on the last base",
-                          default=0.0015, type=float)
-dwgsim_group.add_argument("--dwgsim_options", help="DWGSIM command-line options", default="", required=False)
-
-art_group = main_parser.add_argument_group("ART options")
-art_group.add_argument("--profile_1", metavar="profile_file1", help="ART error profile for first end", default=None,
-                       type=file)
-art_group.add_argument("--profile_2", metavar="profile_file2", help="ART error profile for second end", default=None,
-                       type=file)
-art_group.add_argument("--art_options", help="ART command-line options", default="", required=False)
-
-pbsim_group = main_parser.add_argument_group("PBSIM options")
-pbsim_group.add_argument("--model_qc", metavar="model_qc", help="PBSIM QC model", default=None, type=str)
-
-longislnd_group = main_parser.add_argument_group("LongISLND options")
-longislnd_group.add_argument("--longislnd_options", help="LongISLND options", default="")
-
-args = main_parser.parse_args()
-
-# make the directories we need
-for d in [args.log_dir, args.out_dir]:
-    if not os.path.exists(d):
-        os.makedirs(d)
-
-# Setup logging
-FORMAT = '%(levelname)s %(asctime)-15s %(message)s'
-logging.basicConfig(filename=os.path.join(args.log_dir, "varsim.log"), filemode="w", level=logging.DEBUG, format=FORMAT)
-logger = logging.getLogger(__name__)
-
-
 # ####### Some functions here ##########
 def run_shell_command(cmd, cmd_stdout, cmd_stderr, cmd_dir="."):
     subproc = subprocess.Popen(cmd, stdout=cmd_stdout, stderr=cmd_stderr, cwd=cmd_dir, shell=True, preexec_fn=os.setsid)
@@ -225,338 +81,480 @@ def check_executable(fpath):
         sys.stderr.write("ERROR: File %s is not executable\n" % (fpath))
         sys.exit(1)
 
-# ####### END Some functions here ##########
 
-check_java()
+if __name__ == "__main__":
+    my_dir = os.path.dirname(os.path.realpath(__file__))
 
-# Make sure we can actually execute the executable
-if not args.disable_sim:
-    check_executable(args.simulator_executable.name)
+    default_varsim_jar = os.path.join(my_dir, "VarSim.jar")
 
-processes = []
+    require_varsim_jar = not os.path.isfile(default_varsim_jar)
 
-t_s = time.time()
+    if not os.path.isfile(default_varsim_jar): require_varsim_jar = None
 
-args.vcfs = [os.path.realpath(vcf) for vcf in args.vcfs]
+    main_parser = argparse.ArgumentParser(description="VarSim: A high-fidelity simulation validation framework",
+                                          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    main_parser.add_argument("--out_dir", metavar="DIR",
+                             help="Output directory for the simulated genome, reads and variants", required=False,
+                             default="out")
+    main_parser.add_argument("--work_dir", metavar="DIR", help="Work directory, currently not used", required=False,
+                             default="work")
+    main_parser.add_argument("--log_dir", metavar="DIR", help="Log files of all steps are kept here", required=False,
+                             default="log")
+    main_parser.add_argument("--reference", metavar="FASTA", help="Reference genome that variants will be inserted into",
+                             required=True, type=file)
+    main_parser.add_argument("--seed", metavar="seed", help="Random number seed for reproducibility", type=int, default=0)
+    main_parser.add_argument("--sex", metavar="Sex", help="Sex of the person (MALE/FEMALE)", required=False, type=str,
+                             choices=["MALE", "FEMALE"], default="MALE")
+    main_parser.add_argument("--id", metavar="ID", help="Sample ID to be put in output VCF file", required=True)
+    main_parser.add_argument("--simulator", metavar="SIMULATOR", help="Read simulator to use", required=False, type=str,
+                             choices=["art", "dwgsim", "longislnd"], default="art")
+    main_parser.add_argument("--simulator_executable", metavar="PATH",
+                             help="Path to the executable of the read simulator chosen"
+                             , required=True, type=file)
+    main_parser.add_argument("--varsim_jar", metavar="PATH", help="Path to VarSim.jar", type=file,
+                             default=default_varsim_jar,
+                             required=require_varsim_jar)
+    main_parser.add_argument("--read_length", metavar="LENGTH", help="Length of read to simulate", default=100, type=int)
+    main_parser.add_argument("--nlanes", metavar="INTEGER",
+                             help="Number of lanes to generate, coverage will be divided evenly over the lanes. Simulation is parallized over lanes. Each lane will have its own pair of files",
+                             default=1, type=int)
+    main_parser.add_argument("--total_coverage", metavar="FLOAT", help="Total coverage to simulate", default=1.0,
+                             type=float)
+    main_parser.add_argument("--mean_fragment_size", metavar="INT", help="Mean fragment size to simulate", default=350,
+                             type=int)
+    main_parser.add_argument("--sd_fragment_size", metavar="INT", help="Standard deviation of fragment size to simulate",
+                             default=50, type=int)
+    main_parser.add_argument("--vcfs", metavar="VCF",
+                             help="Addtional list of VCFs to insert into genome, priority is lowest ... highest", nargs="+",
+                             default=[])
+    main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force output bases to be only ACTGN")
+    main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants for simulation")
+    main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files after simulation")
+    main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
 
-if not args.disable_rand_vcf:
-    rand_vcf_stdout = open(os.path.join(args.out_dir, "random.vc.vcf"), "w")
-    rand_vcf_stderr = open(os.path.join(args.log_dir, "RandVCF2VCF.err"), "w")
-    args.vcfs.append(os.path.realpath(rand_vcf_stdout.name))
+    pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
+    pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true",
+                                        help="Disable sampling from the provided small variant VCF")
+    pipeline_control_group.add_argument("--disable_rand_dgv", action="store_true",
+                                        help="Disable sampline from the provided DGV file")
+    pipeline_control_group.add_argument("--disable_vcf2diploid", action="store_true",
+                                        help="Disable diploid genome simulation")
+    pipeline_control_group.add_argument("--disable_sim", action="store_true", help="Disable read simulation")
 
-    rand_vcf_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "randvcf2vcf", "-seed", str(args.seed),
-                        "-t", args.sex,
-                        "-num_snp", str(args.vc_num_snp), "-num_ins", str(args.vc_num_ins), "-num_del",
-                        str(args.vc_num_del),
-                        "-num_mnp", str(args.vc_num_mnp), "-num_complex", str(args.vc_num_complex), "-novel",
-                        str(args.vc_percent_novel),
-                        "-min_len", str(args.vc_min_length_lim), "-max_len", str(args.vc_max_length_lim), "-ref",
-                        os.path.realpath(args.reference.name),
-                        "-prop_het", str(args.vc_prop_het), "-vcf", os.path.realpath(args.vc_in_vcf.name)]
+    # RandVCF2VCF seed num_SNP num_INS num_DEL num_MNP num_COMPLEX percent_novel min_length_lim max_length_lim reference_file file.vcf
+    rand_vcf_group = main_parser.add_argument_group("Small variant simulation options")
+    rand_vcf_group.add_argument("--vc_num_snp", metavar="INTEGER", help="Number of SNPs to sample from small variant VCF",
+                                default=0, type=int)
+    rand_vcf_group.add_argument("--vc_num_ins", metavar="INTEGER",
+                                help="Number of insertions to sample from small variant VCF", default=0, type=int)
+    rand_vcf_group.add_argument("--vc_num_del", metavar="INTEGER",
+                                help="Number of deletions to sample from small variant VCF", default=0, type=int)
+    rand_vcf_group.add_argument("--vc_num_mnp", metavar="INTEGER", help="Number of MNPs to sample from small variant VCF",
+                                default=0, type=int)
+    rand_vcf_group.add_argument("--vc_num_complex", metavar="INTEGER",
+                                help="Number of complex variants to sample from small variant VCF", default=0,
+                                type=int)
+    rand_vcf_group.add_argument("--vc_percent_novel", metavar="FLOAT",
+                                help="Percent variants sampled from small variant VCF that will be moved to novel positions",
+                                default=0, type=float)
+    rand_vcf_group.add_argument("--vc_min_length_lim", metavar="INTEGER",
+                                help="Min length of small variant to accept [inclusive]", default=0, type=int)
+    rand_vcf_group.add_argument("--vc_max_length_lim", metavar="INTEGER",
+                                help="Max length of small variant to accept [inclusive]", default=99,
+                                type=int)
+    rand_vcf_group.add_argument("--vc_in_vcf", metavar="VCF", help="Input small variant VCF, usually dbSNP", type=file,
+                                required=False)
+    rand_vcf_group.add_argument("--vc_prop_het", metavar="FLOAT", help="Proportion of heterozygous small variants",
+                                default=0.6,
+                                type=float)
 
-    p_rand_vcf = subprocess.Popen(rand_vcf_command, stdout=rand_vcf_stdout, stderr=rand_vcf_stderr)
-    logger.info("Executing command " + " ".join(rand_vcf_command) + " with pid " + str(p_rand_vcf.pid))
-    processes.append(p_rand_vcf)
+    # RandDGV2VCF seed num_INS num_DEL num_DUP num_INV percent_novel min_length_lim max_length_lim reference_file insert_seq.txt dgv_file.txt
+    rand_dgv_group = main_parser.add_argument_group("Structural variant simulation options")
+    rand_dgv_group.add_argument("--sv_num_ins", metavar="INTEGER", help="Number of insertions to sample from DGV",
+                                default=20, type=int)
+    rand_dgv_group.add_argument("--sv_num_del", metavar="INTEGER", help="Number of deletions to sample from DGV",
+                                default=20, type=int)
+    rand_dgv_group.add_argument("--sv_num_dup", metavar="INTEGER", help="Number of duplications to sample from DGV",
+                                default=20, type=int)
+    rand_dgv_group.add_argument("--sv_num_inv", metavar="INTEGER", help="Number of inversions to sample from DGV",
+                                default=20, type=int)
+    rand_dgv_group.add_argument("--sv_percent_novel", metavar="FLOAT",
+                                help="Percent variants sampled from DGV that will be moved to novel positions", default=0,
+                                type=float)
+    rand_dgv_group.add_argument("--sv_min_length_lim", metavar="min_length_lim",
+                                help="Min length of structural variant to accept [inclusive]", default=100,
+                                type=int)
+    rand_dgv_group.add_argument("--sv_max_length_lim", metavar="max_length_lim",
+                                help="Max length of structural variant to accept [inclusive]", default=1000000,
+                                type=int)
+    rand_dgv_group.add_argument("--sv_insert_seq", metavar="FILE",
+                                help="Path to file containing concatenation of real insertion sequences", type=file,
+                                required=False)
+    rand_dgv_group.add_argument("--sv_dgv", metavar="DGV_FILE", help="DGV file containing structural variants", type=file,
+                                required=False)
 
-if not args.disable_rand_dgv:
-    rand_dgv_stdout = open(os.path.join(args.out_dir, "random.sv.vcf"), "w")
-    rand_dgv_stderr = open(os.path.join(args.log_dir, "RandDGV2VCF.err"), "w")
-    args.vcfs.append(os.path.realpath(rand_dgv_stdout.name))
+    dwgsim_group = main_parser.add_argument_group("DWGSIM options")
+    dwgsim_group.add_argument("--dwgsim_start_e", metavar="first_base_error_rate", help="Error rate on the first base",
+                              default=0.0001, type=float)
+    dwgsim_group.add_argument("--dwgsim_end_e", metavar="last_base_error_rate", help="Error rate on the last base",
+                              default=0.0015, type=float)
+    dwgsim_group.add_argument("--dwgsim_options", help="DWGSIM command-line options", default="", required=False)
 
-    rand_dgv_command = ["java", "-Xms10g", "-Xmx10g", "-jar", os.path.realpath(args.varsim_jar.name), "randdgv2vcf",
-                        "-t", args.sex,
-                        "-seed", str(args.seed),
-                        "-num_ins", str(args.sv_num_ins), "-num_del", str(args.sv_num_del), "-num_dup",
-                        str(args.sv_num_dup), "-num_inv", str(args.sv_num_inv),
-                        "-novel", str(args.sv_percent_novel), "-min_len", str(args.sv_min_length_lim), "-max_len",
-                        str(args.sv_max_length_lim), "-ref", os.path.realpath(args.reference.name),
-                        "-ins", os.path.realpath(args.sv_insert_seq.name), "-dgv", os.path.realpath(args.sv_dgv.name)]
+    art_group = main_parser.add_argument_group("ART options")
+    art_group.add_argument("--profile_1", metavar="profile_file1", help="ART error profile for first end", default=None,
+                           type=file)
+    art_group.add_argument("--profile_2", metavar="profile_file2", help="ART error profile for second end", default=None,
+                           type=file)
+    art_group.add_argument("--art_options", help="ART command-line options", default="", required=False)
 
-    p_rand_dgv = subprocess.Popen(rand_dgv_command, stdout=rand_dgv_stdout, stderr=rand_dgv_stderr)
-    logger.info("Executing command " + " ".join(rand_dgv_command) + " with pid " + str(p_rand_dgv.pid))
-    processes.append(p_rand_dgv)
+    pbsim_group = main_parser.add_argument_group("PBSIM options")
+    pbsim_group.add_argument("--model_qc", metavar="model_qc", help="PBSIM QC model", default=None, type=str)
 
-processes = monitor_processes(processes, logger)
+    longislnd_group = main_parser.add_argument_group("LongISLND options")
+    longislnd_group.add_argument("--longislnd_options", help="LongISLND options", default="")
 
-merged_reference = os.path.join(args.out_dir, "%s.fa" % (args.id))
-merged_truth_vcf = os.path.join(args.out_dir, "%s.truth.vcf" % (args.id))
-merged_chain = os.path.join(args.out_dir, "merged.chain")
+    args = main_parser.parse_args()
 
-processes = []
-for in_vcf in args.vcfs:
-    out_prefix = os.path.basename(in_vcf)
-    vcfstats_stdout = open(os.path.join(args.out_dir, "%s.stats" % (out_prefix)), "w")
-    vcfstats_stderr = open(os.path.join(args.log_dir, "%s.vcfstats.err" % (out_prefix)), "w")
-    vcfstats_command = ["java", "-Xmx1g", "-Xms1g", "-jar", os.path.realpath(args.varsim_jar.name), "vcfstats", "-vcf",
-                        in_vcf]
-    p_vcfstats = subprocess.Popen(vcfstats_command, stdout=vcfstats_stdout, stderr=vcfstats_stderr)
-    logger.info("Executing command " + " ".join(vcfstats_command) + " with pid " + str(p_vcfstats.pid))
-    processes.append(p_vcfstats)
+    # make the directories we need
+    for d in [args.log_dir, args.out_dir]:
+        if not os.path.exists(d):
+            os.makedirs(d)
 
-if not args.disable_vcf2diploid:
-    args.vcfs.reverse()
-    vcf2diploid_stdout = open(os.path.join(args.out_dir, "vcf2diploid.out"), "w")
-    vcf2diploid_stderr = open(os.path.join(args.log_dir, "vcf2diploid.err"), "w")
-    vcf_arg_list = sum([["-vcf", v] for v in args.vcfs], [])
-    filter_arg_list = ["-pass"] if args.filter else []
-    vcf2diploid_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "vcf2diploid",
-                           "-t", args.sex,
-                           "-id", args.id,
-                           "-chr", os.path.realpath(args.reference.name)] + filter_arg_list + vcf_arg_list
+    # Setup logging
+    FORMAT = '%(levelname)s %(asctime)-15s %(message)s'
+    logging.basicConfig(filename=os.path.join(args.log_dir, "varsim.log"), filemode="w", level=logging.DEBUG, format=FORMAT)
+    logger = logging.getLogger(__name__)
 
-    p_vcf2diploid = subprocess.Popen(vcf2diploid_command, stdout=vcf2diploid_stdout, stderr=vcf2diploid_stderr,
-                                     cwd=args.out_dir)
-    logger.info("Executing command " + " ".join(vcf2diploid_command) + " with pid " + str(p_vcf2diploid.pid))
-    processes.append(p_vcf2diploid)
+    check_java()
+
+    # Make sure we can actually execute the executable
+    if not args.disable_sim:
+        check_executable(args.simulator_executable.name)
+
+    processes = []
+
+    t_s = time.time()
+
+    args.vcfs = [os.path.realpath(vcf) for vcf in args.vcfs]
+
+    if not args.disable_rand_vcf:
+        rand_vcf_stdout = open(os.path.join(args.out_dir, "random.vc.vcf"), "w")
+        rand_vcf_stderr = open(os.path.join(args.log_dir, "RandVCF2VCF.err"), "w")
+        args.vcfs.append(os.path.realpath(rand_vcf_stdout.name))
+
+        rand_vcf_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "randvcf2vcf", "-seed", str(args.seed),
+                            "-t", args.sex,
+                            "-num_snp", str(args.vc_num_snp), "-num_ins", str(args.vc_num_ins), "-num_del",
+                            str(args.vc_num_del),
+                            "-num_mnp", str(args.vc_num_mnp), "-num_complex", str(args.vc_num_complex), "-novel",
+                            str(args.vc_percent_novel),
+                            "-min_len", str(args.vc_min_length_lim), "-max_len", str(args.vc_max_length_lim), "-ref",
+                            os.path.realpath(args.reference.name),
+                            "-prop_het", str(args.vc_prop_het), "-vcf", os.path.realpath(args.vc_in_vcf.name)]
+
+        p_rand_vcf = subprocess.Popen(rand_vcf_command, stdout=rand_vcf_stdout, stderr=rand_vcf_stderr)
+        logger.info("Executing command " + " ".join(rand_vcf_command) + " with pid " + str(p_rand_vcf.pid))
+        processes.append(p_rand_vcf)
+
+    if not args.disable_rand_dgv:
+        rand_dgv_stdout = open(os.path.join(args.out_dir, "random.sv.vcf"), "w")
+        rand_dgv_stderr = open(os.path.join(args.log_dir, "RandDGV2VCF.err"), "w")
+        args.vcfs.append(os.path.realpath(rand_dgv_stdout.name))
+
+        rand_dgv_command = ["java", "-Xms10g", "-Xmx10g", "-jar", os.path.realpath(args.varsim_jar.name), "randdgv2vcf",
+                            "-t", args.sex,
+                            "-seed", str(args.seed),
+                            "-num_ins", str(args.sv_num_ins), "-num_del", str(args.sv_num_del), "-num_dup",
+                            str(args.sv_num_dup), "-num_inv", str(args.sv_num_inv),
+                            "-novel", str(args.sv_percent_novel), "-min_len", str(args.sv_min_length_lim), "-max_len",
+                            str(args.sv_max_length_lim), "-ref", os.path.realpath(args.reference.name),
+                            "-ins", os.path.realpath(args.sv_insert_seq.name), "-dgv", os.path.realpath(args.sv_dgv.name)]
+
+        p_rand_dgv = subprocess.Popen(rand_dgv_command, stdout=rand_dgv_stdout, stderr=rand_dgv_stderr)
+        logger.info("Executing command " + " ".join(rand_dgv_command) + " with pid " + str(p_rand_dgv.pid))
+        processes.append(p_rand_dgv)
 
     processes = monitor_processes(processes, logger)
 
-    # Now concatenate the .fa from vcf2diploid
-    contigs = get_contigs_list(args.reference.name)
-    with open(merged_reference, "w") as merged_fa:
-        for contig in contigs:
-            for strand in ["maternal", "paternal"]:
-                fasta = os.path.join(args.out_dir, "%s_%s_%s.fa" % (contig, args.id, strand))
-                if not os.path.isfile(fasta):
-                    continue
-                with open(fasta) as chromosome_fasta:
-                    shutil.copyfileobj(chromosome_fasta, merged_fa)
-    if os.path.getsize(merged_reference) == 0:
-        logger.error("Merged FASTA is empty. Something bad happened. Exiting")
-        raise RuntimeError("Empty FASTA generated by vcf2diploid")
+    merged_reference = os.path.join(args.out_dir, "%s.fa" % (args.id))
+    merged_truth_vcf = os.path.join(args.out_dir, "%s.truth.vcf" % (args.id))
+    merged_chain = os.path.join(args.out_dir, "merged.chain")
 
-    # contatenate the vcfs
-    with open(merged_truth_vcf, "w") as merged_vcf:
-        first_file = True
-        for contig in contigs:
-            chr_vcf = os.path.join(args.out_dir, "%s_%s.vcf" % (contig, args.id))
-            if not os.path.isfile(chr_vcf):
-                continue
-            with open(chr_vcf) as chr_vcf_file:
-                for line in chr_vcf_file:
-                    line = line.strip()
-                    if len(line) == 0:
+    processes = []
+    for in_vcf in args.vcfs:
+        out_prefix = os.path.basename(in_vcf)
+        vcfstats_stdout = open(os.path.join(args.out_dir, "%s.stats" % (out_prefix)), "w")
+        vcfstats_stderr = open(os.path.join(args.log_dir, "%s.vcfstats.err" % (out_prefix)), "w")
+        vcfstats_command = ["java", "-Xmx1g", "-Xms1g", "-jar", os.path.realpath(args.varsim_jar.name), "vcfstats", "-vcf",
+                            in_vcf]
+        p_vcfstats = subprocess.Popen(vcfstats_command, stdout=vcfstats_stdout, stderr=vcfstats_stderr)
+        logger.info("Executing command " + " ".join(vcfstats_command) + " with pid " + str(p_vcfstats.pid))
+        processes.append(p_vcfstats)
+
+    if not args.disable_vcf2diploid:
+        args.vcfs.reverse()
+        vcf2diploid_stdout = open(os.path.join(args.out_dir, "vcf2diploid.out"), "w")
+        vcf2diploid_stderr = open(os.path.join(args.log_dir, "vcf2diploid.err"), "w")
+        vcf_arg_list = sum([["-vcf", v] for v in args.vcfs], [])
+        filter_arg_list = ["-pass"] if args.filter else []
+        vcf2diploid_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "vcf2diploid",
+                               "-t", args.sex,
+                               "-id", args.id,
+                               "-chr", os.path.realpath(args.reference.name)] + filter_arg_list + vcf_arg_list
+
+        p_vcf2diploid = subprocess.Popen(vcf2diploid_command, stdout=vcf2diploid_stdout, stderr=vcf2diploid_stderr,
+                                         cwd=args.out_dir)
+        logger.info("Executing command " + " ".join(vcf2diploid_command) + " with pid " + str(p_vcf2diploid.pid))
+        processes.append(p_vcf2diploid)
+
+        processes = monitor_processes(processes, logger)
+
+        # Now concatenate the .fa from vcf2diploid
+        contigs = get_contigs_list(args.reference.name)
+        with open(merged_reference, "w") as merged_fa:
+            for contig in contigs:
+                for strand in ["maternal", "paternal"]:
+                    fasta = os.path.join(args.out_dir, "%s_%s_%s.fa" % (contig, args.id, strand))
+                    if not os.path.isfile(fasta):
                         continue
-                    if not first_file:
-                        if line[0] == "#":
+                    with open(fasta) as chromosome_fasta:
+                        shutil.copyfileobj(chromosome_fasta, merged_fa)
+        if os.path.getsize(merged_reference) == 0:
+            logger.error("Merged FASTA is empty. Something bad happened. Exiting")
+            raise RuntimeError("Empty FASTA generated by vcf2diploid")
+
+        # contatenate the vcfs
+        with open(merged_truth_vcf, "w") as merged_vcf:
+            first_file = True
+            for contig in contigs:
+                chr_vcf = os.path.join(args.out_dir, "%s_%s.vcf" % (contig, args.id))
+                if not os.path.isfile(chr_vcf):
+                    continue
+                with open(chr_vcf) as chr_vcf_file:
+                    for line in chr_vcf_file:
+                        line = line.strip()
+                        if len(line) == 0:
                             continue
-                    merged_vcf.write(line)
-                    merged_vcf.write('\n')
+                        if not first_file:
+                            if line[0] == "#":
+                                continue
+                        merged_vcf.write(line)
+                        merged_vcf.write('\n')
 
-                first_file = False
+                    first_file = False
 
 
-    # Merge the chain files
-    with open(merged_chain, "w") as merged_chain_file:
-        for strand in ["maternal", "paternal"]:
-            with open(os.path.join(args.out_dir, "%s.chain" % (strand))) as strand_chain:
-                shutil.copyfileobj(strand_chain, merged_chain_file)
+        # Merge the chain files
+        with open(merged_chain, "w") as merged_chain_file:
+            for strand in ["maternal", "paternal"]:
+                with open(os.path.join(args.out_dir, "%s.chain" % (strand))) as strand_chain:
+                    shutil.copyfileobj(strand_chain, merged_chain_file)
 
-    vcfstats_stdout = open(os.path.join(args.out_dir, "%s.truth.vcf.stats" % (args.id)), "w")
-    vcfstats_stderr = open(os.path.join(args.log_dir, "%s.truth.vcf.vcfstats.err" % (args.id)), "w")
-    p_vcfstats = subprocess.Popen(
-        ["java", "-Xmx1g", "-Xms1g", "-jar", os.path.realpath(args.varsim_jar.name), "vcfstats", "-vcf",
-         merged_truth_vcf], stdout=vcfstats_stdout, stderr=vcfstats_stderr)
-    logger.info("Executing command " + " ".join(vcfstats_command) + " with pid " + str(p_vcfstats.pid))
-    monitor_processes([p_vcfstats], logger)
+        vcfstats_stdout = open(os.path.join(args.out_dir, "%s.truth.vcf.stats" % (args.id)), "w")
+        vcfstats_stderr = open(os.path.join(args.log_dir, "%s.truth.vcf.vcfstats.err" % (args.id)), "w")
+        p_vcfstats = subprocess.Popen(
+            ["java", "-Xmx1g", "-Xms1g", "-jar", os.path.realpath(args.varsim_jar.name), "vcfstats", "-vcf",
+             merged_truth_vcf], stdout=vcfstats_stdout, stderr=vcfstats_stderr)
+        logger.info("Executing command " + " ".join(vcfstats_command) + " with pid " + str(p_vcfstats.pid))
+        monitor_processes([p_vcfstats], logger)
 
-if processes:
-    processes = monitor_processes(processes, logger)
+    if processes:
+        processes = monitor_processes(processes, logger)
 
-merged_map = os.path.join(args.out_dir, "%s.map" % (args.id))
+    merged_map = os.path.join(args.out_dir, "%s.map" % (args.id))
 
-# Now generate the reads using art/pbsim/dwgsim
-tmp_files = []
-if not args.disable_sim:
-    fifos = []
-    fastqs = []
-    sim_ts = time.time()
-    coverage_per_lane = args.total_coverage * 0.5 / args.nlanes
-    processes = []
+    # Now generate the reads using art/pbsim/dwgsim
+    tmp_files = []
+    if not args.disable_sim:
+        fifos = []
+        fastqs = []
+        sim_ts = time.time()
+        coverage_per_lane = args.total_coverage * 0.5 / args.nlanes
+        processes = []
 
-    fifo_src_dst = []
-    if args.simulator == "dwgsim":
-        for i, end in itertools.product(xrange(args.nlanes), [1, 2]):
-            fifo_src_dst.append(
-                ("simulated.lane%d.read%d.fastq" % (i, end),
-                 "simulated.lane%d.read%d.fq.gz" % (i, end)))
-    elif args.simulator == "art":
-        for i, end, suffix in itertools.product(xrange(args.nlanes), [1, 2], ["fq", "aln"]):
-            fifo_src_dst.append(("simulated.lane%d.read%d.%s" % (i, end, suffix),
-                                 "simulated.lane%d.read%d.%s.gz" % (i, end, suffix)))
-    elif args.simulator == "pbsim":
-        for i, end, suffix in itertools.product(xrange(args.nlanes), [1, 2], ["fq", "maf"]): # the '2' read files are empty and for compatibility only
-            fifo_src_dst.append(("simulated.lane%d.read%d.%s" % (i, end, suffix),
-                                 "simulated.lane%d.read%d.%s.gz" % (i, end, suffix)))
-    elif args.simulator == "longislnd":
-        pass
-    else:
-        raise NotImplementedError("simulation method " + args.simulator + " not implemented");
+        fifo_src_dst = []
+        if args.simulator == "dwgsim":
+            for i, end in itertools.product(xrange(args.nlanes), [1, 2]):
+                fifo_src_dst.append(
+                    ("simulated.lane%d.read%d.fastq" % (i, end),
+                     "simulated.lane%d.read%d.fq.gz" % (i, end)))
+        elif args.simulator == "art":
+            for i, end, suffix in itertools.product(xrange(args.nlanes), [1, 2], ["fq", "aln"]):
+                fifo_src_dst.append(("simulated.lane%d.read%d.%s" % (i, end, suffix),
+                                     "simulated.lane%d.read%d.%s.gz" % (i, end, suffix)))
+        elif args.simulator == "pbsim":
+            for i, end, suffix in itertools.product(xrange(args.nlanes), [1, 2], ["fq", "maf"]): # the '2' read files are empty and for compatibility only
+                fifo_src_dst.append(("simulated.lane%d.read%d.%s" % (i, end, suffix),
+                                     "simulated.lane%d.read%d.%s.gz" % (i, end, suffix)))
+        elif args.simulator == "longislnd":
+            pass
+        else:
+            raise NotImplementedError("simulation method " + args.simulator + " not implemented");
 
-    for fifo_name, dst in fifo_src_dst:
-        fifos.append(os.path.join(args.out_dir, fifo_name))
-        if os.path.exists(fifos[-1]): os.remove(fifos[-1])
-        os.mkfifo(fifos[-1])
+        for fifo_name, dst in fifo_src_dst:
+            fifos.append(os.path.join(args.out_dir, fifo_name))
+            if os.path.exists(fifos[-1]): os.remove(fifos[-1])
+            os.mkfifo(fifos[-1])
 
-        gzip_stderr = open(os.path.join(args.log_dir, "gzip.%s" % (fifo_name)), "w")
-        gzip_command = "cat %s | gzip -2 > %s" % (fifos[-1], os.path.join(args.out_dir, dst))
-        gzip_p = Process(target=run_shell_command, args=(gzip_command, None, gzip_stderr))
-        gzip_p.start()
-        processes.append(gzip_p)
-        logger.info("Executing command %s" % (gzip_command) + " with pid " + str(gzip_p.pid))
-        tmp_files.append(os.path.join(args.out_dir, dst))
+            gzip_stderr = open(os.path.join(args.log_dir, "gzip.%s" % (fifo_name)), "w")
+            gzip_command = "cat %s | gzip -2 > %s" % (fifos[-1], os.path.join(args.out_dir, dst))
+            gzip_p = Process(target=run_shell_command, args=(gzip_command, None, gzip_stderr))
+            gzip_p.start()
+            processes.append(gzip_p)
+            logger.info("Executing command %s" % (gzip_command) + " with pid " + str(gzip_p.pid))
+            tmp_files.append(os.path.join(args.out_dir, dst))
 
-    if args.simulator == "dwgsim":
-        for i in xrange(args.nlanes):
-            dwgsim_command = [os.path.realpath(args.simulator_executable.name), "-e",
-                              "%s,%s" % (args.dwgsim_start_e, args.dwgsim_end_e),
-                              "-E", "%s,%s" % (args.dwgsim_start_e, args.dwgsim_end_e), args.dwgsim_options,
-                              "-d", str(args.mean_fragment_size), "-s", str(args.sd_fragment_size), "-C",
-                              str(coverage_per_lane), "-1", str(args.read_length), "-2", str(args.read_length),
-                              "-z", str(i), merged_reference, os.path.join(args.out_dir, "simulated.lane%d" % (i))]
-            dwgsim_command = " ".join(dwgsim_command)
+        if args.simulator == "dwgsim":
+            for i in xrange(args.nlanes):
+                dwgsim_command = [os.path.realpath(args.simulator_executable.name), "-e",
+                                  "%s,%s" % (args.dwgsim_start_e, args.dwgsim_end_e),
+                                  "-E", "%s,%s" % (args.dwgsim_start_e, args.dwgsim_end_e), args.dwgsim_options,
+                                  "-d", str(args.mean_fragment_size), "-s", str(args.sd_fragment_size), "-C",
+                                  str(coverage_per_lane), "-1", str(args.read_length), "-2", str(args.read_length),
+                                  "-z", str(i), merged_reference, os.path.join(args.out_dir, "simulated.lane%d" % (i))]
+                dwgsim_command = " ".join(dwgsim_command)
 
-            dwgsim_stdout = open(os.path.join(args.log_dir, "dwgsim.lane%d.out" % (i)), "w")
-            dwgsim_stderr = open(os.path.join(args.log_dir, "dwgsim.lane%d.err" % (i)), "w")
-            dwgsim_p = Process(target=run_shell_command, args=(dwgsim_command, dwgsim_stdout, dwgsim_stderr))
-            dwgsim_p.start()
-            processes.append(dwgsim_p)
-            logger.info("Executing command " + dwgsim_command + " with pid " + str(dwgsim_p.pid))
-    elif args.simulator == "art":
-        profile_opts = []
-        if args.profile_1 is not None and args.profile_2 is not None:
-            profile_opts = ["-1", args.profile_1.name, "-2", args.profile_2.name]
+                dwgsim_stdout = open(os.path.join(args.log_dir, "dwgsim.lane%d.out" % (i)), "w")
+                dwgsim_stderr = open(os.path.join(args.log_dir, "dwgsim.lane%d.err" % (i)), "w")
+                dwgsim_p = Process(target=run_shell_command, args=(dwgsim_command, dwgsim_stdout, dwgsim_stderr))
+                dwgsim_p.start()
+                processes.append(dwgsim_p)
+                logger.info("Executing command " + dwgsim_command + " with pid " + str(dwgsim_p.pid))
+        elif args.simulator == "art":
+            profile_opts = []
+            if args.profile_1 is not None and args.profile_2 is not None:
+                profile_opts = ["-1", args.profile_1.name, "-2", args.profile_2.name]
 
-        for i in xrange(args.nlanes):
-            art_command = [args.simulator_executable.name] + profile_opts + ["-i", merged_reference, "-p",
-                                                                             "-l", str(args.read_length), "-f",
-                                                                             str(coverage_per_lane),
-                                                                             "-m", str(args.mean_fragment_size),
-                                                                             "-s", str(args.sd_fragment_size), "-rs",
-                                                                             str(i),
-                                                                             args.art_options, "-o",
-                                                                             os.path.join(args.out_dir,
-                                                                                          "simulated.lane%d.read" % (
-                                                                                              i))]
-            art_command = " ".join(art_command)
-            art_stdout = open(os.path.join(args.log_dir, "art.lane%d.out" % (i)), "w")
-            art_stderr = open(os.path.join(args.log_dir, "art.lane%d.err" % (i)), "w")
-            art_p = Process(target=run_shell_command, args=(art_command, art_stdout, art_stderr))
-            art_p.start()
-            processes.append(art_p)
-            logger.info("Executing command " + art_command + " with pid " + str(art_p.pid))
-    elif args.simulator == "pbsim":
-        nRef = 0;
-        with open(merged_reference, 'r') as fa:
-            nRef = sum(1 for line in fa if len(line) > 0 and line[0] == '>')
-        assert 0 < nRef < 10000
+            for i in xrange(args.nlanes):
+                art_command = [args.simulator_executable.name] + profile_opts + ["-i", merged_reference, "-p",
+                                                                                 "-l", str(args.read_length), "-f",
+                                                                                 str(coverage_per_lane),
+                                                                                 "-m", str(args.mean_fragment_size),
+                                                                                 "-s", str(args.sd_fragment_size), "-rs",
+                                                                                 str(i),
+                                                                                 args.art_options, "-o",
+                                                                                 os.path.join(args.out_dir,
+                                                                                              "simulated.lane%d.read" % (
+                                                                                                  i))]
+                art_command = " ".join(art_command)
+                art_stdout = open(os.path.join(args.log_dir, "art.lane%d.out" % (i)), "w")
+                art_stderr = open(os.path.join(args.log_dir, "art.lane%d.err" % (i)), "w")
+                art_p = Process(target=run_shell_command, args=(art_command, art_stdout, art_stderr))
+                art_p.start()
+                processes.append(art_p)
+                logger.info("Executing command " + art_command + " with pid " + str(art_p.pid))
+        elif args.simulator == "pbsim":
+            nRef = 0;
+            with open(merged_reference, 'r') as fa:
+                nRef = sum(1 for line in fa if len(line) > 0 and line[0] == '>')
+            assert 0 < nRef < 10000
 
-        for i in xrange(args.nlanes):
-            tmp_prefix = os.path.join(args.out_dir, "simulated.lane%d" % (i));
-            tmp_fastq_list = " ".join(
-                "%s_%s.fastq" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
-            tmp_maf_list = " ".join(
-                "%s_%s.maf" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
-            tmp_ref_list = " ".join(
-                "%s_%s.ref" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
-            pbsim_command = [os.path.realpath(args.simulator_executable.name),
-                             "--data-type", "CLR",
-                             "--depth", str(coverage_per_lane),
-                             "--model_qc", args.model_qc,
-                             "--seed", str(2089 * (i + 1)),
-                             merged_reference,
-                             "--prefix", tmp_prefix,
-                             "&& ( cat", tmp_fastq_list, "> %s.read1.fq" % (tmp_prefix), ")",
-                             # this cat is i/o bound, need optimization of piping
-                             "&& ( cat", tmp_maf_list, "> %s.read1.maf" % (tmp_prefix),
-                             ")"  # this cat is i/o bound, need optimization of piping
-                             "&& ( head -q -n1 ", tmp_ref_list, "> %s.ref" % (tmp_prefix),
-                             ")"  # make reference header list
-                             "&& ( echo > %s.read2.fq" % (tmp_prefix), ")",  # dummy file
-                             "&& ( echo > %s.read2.maf" % (tmp_prefix), ")"  # dummy file
-                             ]
+            for i in xrange(args.nlanes):
+                tmp_prefix = os.path.join(args.out_dir, "simulated.lane%d" % (i));
+                tmp_fastq_list = " ".join(
+                    "%s_%s.fastq" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
+                tmp_maf_list = " ".join(
+                    "%s_%s.maf" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
+                tmp_ref_list = " ".join(
+                    "%s_%s.ref" % (tmp_prefix, "0" * (4 - len(str(idx))) + str(idx)) for idx in range(1, nRef + 1))
+                pbsim_command = [os.path.realpath(args.simulator_executable.name),
+                                 "--data-type", "CLR",
+                                 "--depth", str(coverage_per_lane),
+                                 "--model_qc", args.model_qc,
+                                 "--seed", str(2089 * (i + 1)),
+                                 merged_reference,
+                                 "--prefix", tmp_prefix,
+                                 "&& ( cat", tmp_fastq_list, "> %s.read1.fq" % (tmp_prefix), ")",
+                                 # this cat is i/o bound, need optimization of piping
+                                 "&& ( cat", tmp_maf_list, "> %s.read1.maf" % (tmp_prefix),
+                                 ")"  # this cat is i/o bound, need optimization of piping
+                                 "&& ( head -q -n1 ", tmp_ref_list, "> %s.ref" % (tmp_prefix),
+                                 ")"  # make reference header list
+                                 "&& ( echo > %s.read2.fq" % (tmp_prefix), ")",  # dummy file
+                                 "&& ( echo > %s.read2.maf" % (tmp_prefix), ")"  # dummy file
+                                 ]
 
-            pbsim_command = " ".join(pbsim_command)
+                pbsim_command = " ".join(pbsim_command)
 
-            pbsim_stdout = open(os.path.join(args.log_dir, "pbsim.lane%d.out" % (i)), "w")
-            pbsim_stderr = open(os.path.join(args.log_dir, "pbsim.lane%d.err" % (i)), "w")
-            pbsim_p = Process(target=run_shell_command, args=(pbsim_command, pbsim_stdout, pbsim_stderr))
-            pbsim_p.start()
-            processes.append(pbsim_p)
-            logger.info("Executing command " + pbsim_command + " with pid " + str(pbsim_p.pid))
-    elif args.simulator == "longislnd":
-        longislnd_command = [args.simulator_executable.name, args.longislnd_options, "--coverage", str(args.total_coverage), "--out", os.path.join(args.out_dir, "longislnd_sim"), "--fasta", merged_reference]
-        longislnd_command = " ".join(longislnd_command)
-        longislnd_stdout = open(os.path.join(args.log_dir, "longislnd.out"), "w")
-        longislnd_stderr = open(os.path.join(args.log_dir, "longislnd.err"), "w")
-        longislnd_p = Process(target=run_shell_command, args=(longislnd_command, longislnd_stdout, longislnd_stderr))
-        longislnd_p.start()
-        processes.append(longislnd_p)
-        logger.info("Executing command " + longislnd_command + " with pid " + str(longislnd_p.pid))
-    else:
-        raise NotImplementedError("simulation method " + args.simulator + " not implemented");
+                pbsim_stdout = open(os.path.join(args.log_dir, "pbsim.lane%d.out" % (i)), "w")
+                pbsim_stderr = open(os.path.join(args.log_dir, "pbsim.lane%d.err" % (i)), "w")
+                pbsim_p = Process(target=run_shell_command, args=(pbsim_command, pbsim_stdout, pbsim_stderr))
+                pbsim_p.start()
+                processes.append(pbsim_p)
+                logger.info("Executing command " + pbsim_command + " with pid " + str(pbsim_p.pid))
+        elif args.simulator == "longislnd":
+            longislnd_command = [args.simulator_executable.name, args.longislnd_options, "--coverage", str(args.total_coverage), "--out", os.path.join(args.out_dir, "longislnd_sim"), "--fasta", merged_reference]
+            longislnd_command = " ".join(longislnd_command)
+            longislnd_stdout = open(os.path.join(args.log_dir, "longislnd.out"), "w")
+            longislnd_stderr = open(os.path.join(args.log_dir, "longislnd.err"), "w")
+            longislnd_p = Process(target=run_shell_command, args=(longislnd_command, longislnd_stdout, longislnd_stderr))
+            longislnd_p.start()
+            processes.append(longislnd_p)
+            logger.info("Executing command " + longislnd_command + " with pid " + str(longislnd_p.pid))
+        else:
+            raise NotImplementedError("simulation method " + args.simulator + " not implemented");
 
-    monitor_multiprocesses(processes, logger)
-    processes = []
+        monitor_multiprocesses(processes, logger)
+        processes = []
 
-    logger.info("Read generation took %g seconds" % (time.time() - sim_ts))
+        logger.info("Read generation took %g seconds" % (time.time() - sim_ts))
 
-    sim_t_liftover = time.time()
+        sim_t_liftover = time.time()
 
-    # Now start lifting over the gzipped files
-    if args.simulator != "longislnd":
-        for i in xrange(args.nlanes):
-            liftover_stdout = open(os.path.join(args.log_dir, "lane%d.out" % (i)), "w")
-            liftover_stderr = open(os.path.join(args.log_dir, "liftover%d.log" % (i)), "w")
-            fastq_liftover_command = "java -server -Xms4g -Xmx4g -jar %s fastq_liftover -map %s -id %d " \
-                                     "-fastq <(gunzip -c %s/simulated.lane%d.read1.fq.gz) " \
-                                     "-fastq <(gunzip -c %s/simulated.lane%d.read2.fq.gz) " \
-                                     "-out >(gzip -1 > %s/lane%d.read1.fq.gz) " \
-                                     "-out >(gzip -1 > %s/lane%d.read2.fq.gz)" % (
-                                         os.path.realpath(args.varsim_jar.name), merged_map, i, args.out_dir, i,
-                                         args.out_dir, i, args.out_dir, i,
-                                         args.out_dir, i)
-            if args.force_five_base_encoding:
-                fastq_liftover_command += " -force_five_base_encoding "
-            if args.simulator == "art":
-                fastq_liftover_command += " -type art " \
-                                          "-aln <(gunzip -c %s/simulated.lane%d.read1.aln.gz) " \
-                                          "-aln <(gunzip -c %s/simulated.lane%d.read2.aln.gz)" % (
-                                              args.out_dir, i, args.out_dir, i)
-            elif args.simulator == "pbsim":
-                fastq_liftover_command += " -type pbsim " \
-                                          "-maf <(gunzip -c %s/simulated.lane%d.read1.maf.gz) " \
-                                          "-ref %s/simulated.lane%d.ref " % (args.out_dir, i, args.out_dir, i)
-            fastq_liftover_command = "bash -c \"%s\"" % (fastq_liftover_command)
-            liftover_p = Process(target=run_shell_command, args=(fastq_liftover_command, liftover_stdout, liftover_stderr))
-            liftover_p.start()
-            processes.append(liftover_p)
-            fastqs.append(os.path.join(args.out_dir, "lane%d.read%d.fq.gz" % (i, end)))
-            logger.info("Executing command " + fastq_liftover_command + " with pid " + str(liftover_p.pid))
-    else:
-        # liftover the read map files
-        read_maps = " ".join(map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd_sim", "*.bed"))))
-        read_map_liftover_command = "java -server -jar %s longislnd_liftover " % args.varsim_jar.name + read_maps + " -map %s " % merged_map + " -out %s" % (os.path.join(args.out_dir, args.id + ".truth.map"))
-        read_map_liftover_stderr = open(os.path.join(args.log_dir, "longislnd_liftover.err"), "w")
-        read_map_liftover_p = Process(target=run_shell_command, args=(read_map_liftover_command, None, read_map_liftover_stderr))
-        read_map_liftover_p.start()
-        processes.append(read_map_liftover_p)
-        logger.info("Executing command " + read_map_liftover_command + " with pid " + str(read_map_liftover_p.pid))
+        # Now start lifting over the gzipped files
+        if args.simulator != "longislnd":
+            for i in xrange(args.nlanes):
+                liftover_stdout = open(os.path.join(args.log_dir, "lane%d.out" % (i)), "w")
+                liftover_stderr = open(os.path.join(args.log_dir, "liftover%d.log" % (i)), "w")
+                fastq_liftover_command = "java -server -Xms4g -Xmx4g -jar %s fastq_liftover -map %s -id %d " \
+                                         "-fastq <(gunzip -c %s/simulated.lane%d.read1.fq.gz) " \
+                                         "-fastq <(gunzip -c %s/simulated.lane%d.read2.fq.gz) " \
+                                         "-out >(gzip -1 > %s/lane%d.read1.fq.gz) " \
+                                         "-out >(gzip -1 > %s/lane%d.read2.fq.gz)" % (
+                                             os.path.realpath(args.varsim_jar.name), merged_map, i, args.out_dir, i,
+                                             args.out_dir, i, args.out_dir, i,
+                                             args.out_dir, i)
+                if args.force_five_base_encoding:
+                    fastq_liftover_command += " -force_five_base_encoding "
+                if args.simulator == "art":
+                    fastq_liftover_command += " -type art " \
+                                              "-aln <(gunzip -c %s/simulated.lane%d.read1.aln.gz) " \
+                                              "-aln <(gunzip -c %s/simulated.lane%d.read2.aln.gz)" % (
+                                                  args.out_dir, i, args.out_dir, i)
+                elif args.simulator == "pbsim":
+                    fastq_liftover_command += " -type pbsim " \
+                                              "-maf <(gunzip -c %s/simulated.lane%d.read1.maf.gz) " \
+                                              "-ref %s/simulated.lane%d.ref " % (args.out_dir, i, args.out_dir, i)
+                fastq_liftover_command = "bash -c \"%s\"" % (fastq_liftover_command)
+                liftover_p = Process(target=run_shell_command, args=(fastq_liftover_command, liftover_stdout, liftover_stderr))
+                liftover_p.start()
+                processes.append(liftover_p)
+                fastqs.append(os.path.join(args.out_dir, "lane%d.read%d.fq.gz" % (i, end)))
+                logger.info("Executing command " + fastq_liftover_command + " with pid " + str(liftover_p.pid))
+        else:
+            # liftover the read map files
+            read_maps = " ".join(map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd_sim", "*.bed"))))
+            read_map_liftover_command = "java -server -jar %s longislnd_liftover " % args.varsim_jar.name + read_maps + " -map %s " % merged_map + " -out %s" % (os.path.join(args.out_dir, args.id + ".truth.map"))
+            read_map_liftover_stderr = open(os.path.join(args.log_dir, "longislnd_liftover.err"), "w")
+            read_map_liftover_p = Process(target=run_shell_command, args=(read_map_liftover_command, None, read_map_liftover_stderr))
+            read_map_liftover_p.start()
+            processes.append(read_map_liftover_p)
+            logger.info("Executing command " + read_map_liftover_command + " with pid " + str(read_map_liftover_p.pid))
 
-    monitor_multiprocesses(processes, logger)
+        monitor_multiprocesses(processes, logger)
 
-    logger.info("Liftover took %g seconds" % (time.time() - sim_t_liftover))
+        logger.info("Liftover took %g seconds" % (time.time() - sim_t_liftover))
 
-    sim_te = max(sim_ts + 1, time.time())
-    bytes_written = sum([os.path.getsize(fastq) for fastq in fastqs])
-    logger.info("Took %g seconds, %ld Mbytes written, %g MB/s" % (
-        sim_te - sim_ts, bytes_written / 1024.0 / 1024.0, bytes_written / 1024.0 / 1024.0 / (sim_te - sim_ts)))
+        sim_te = max(sim_ts + 1, time.time())
+        bytes_written = sum([os.path.getsize(fastq) for fastq in fastqs])
+        logger.info("Took %g seconds, %ld Mbytes written, %g MB/s" % (
+            sim_te - sim_ts, bytes_written / 1024.0 / 1024.0, bytes_written / 1024.0 / 1024.0 / (sim_te - sim_ts)))
 
-    for fifo in fifos:
-        os.remove(fifo)
+        for fifo in fifos:
+            os.remove(fifo)
 
-if not args.keep_temp:
-    logger.info("Cleaning up intermediate files")
-    for f in tmp_files:
-        os.remove(f)
-logger.info("Done! (%g hours)" % ((time.time() - t_s) / 3600.0))
+    if not args.keep_temp:
+        logger.info("Cleaning up intermediate files")
+        for f in tmp_files:
+            os.remove(f)
+    logger.info("Done! (%g hours)" % ((time.time() - t_s) / 3600.0))

--- a/varsim.py
+++ b/varsim.py
@@ -146,7 +146,7 @@ pbsim_group = main_parser.add_argument_group("PBSIM options")
 pbsim_group.add_argument("--model_qc", metavar="model_qc", help="PBSIM QC model", default=None, type=str)
 
 longislnd_group = main_parser.add_argument_group("LongISLND options")
-longislnd_group.add_argument("--longislnd_opts", help="LongISLND options", default="")
+longislnd_group.add_argument("--longislnd_options", help="LongISLND options", default="")
 
 args = main_parser.parse_args()
 

--- a/varsim.py
+++ b/varsim.py
@@ -476,9 +476,10 @@ if not args.disable_sim:
             logger.info("Executing command " + pbsim_command + " with pid " + str(pbsim_p.pid))
     elif args.simulator == "longislnd":
         longislnd_command = [args.simulator_executable, args.longislnd_options, "--coverage", str(args.total_coverage), "--out", os.path.join(args.out_dir, "longislnd_sim"), "--fasta", merged_reference]
+        longislnd_command = " ".join(longislnd_command)
         longislnd_stdout = open(os.path.join(args.log_dir, "longislnd.out"), "w")
         longislnd_stderr = open(os.path.join(args.log_dir, "longislnd.err"), "w")
-        longislnd_p = Process(target=run_shell_command, args=(" ".join(longislnd_command), longislnd_stdout, longislnd_stderr))
+        longislnd_p = Process(target=run_shell_command, args=(longislnd_command, longislnd_stdout, longislnd_stderr))
         longislnd_p.start()
         processes.append(longislnd_p)
         logger.info("Executing command " + " ".join(longislnd_command) + " with pid " + str(longislnd_p.pid))

--- a/varsim.py
+++ b/varsim.py
@@ -19,6 +19,13 @@ def get_contigs_list(reference):
         contigs = [line.strip().split()[0] for line in fai_file.readlines()]
     return contigs
 
+# Check java version to make sure it is Java 8
+def check_java():
+    jv = filter(lambda x: x.startswith("java version"), subprocess.check_output("java -version", stderr=subprocess.STDOUT, shell=True).split("\n"))[0].split()[2].replace("\"", "")
+    if LooseVersion(jv) < LooseVersion("1.8"):
+        logger.error("VarSim requires Java 1.8 to be on the path.")
+        raise EnvironmentError("VarSim requires Java 1.8 to be on the path")
+
 
 my_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -218,11 +225,7 @@ def check_executable(fpath):
 
 # ####### END Some functions here ##########
 
-# Check java version to make sure it is Java 8
-jv = filter(lambda x: x.startswith("java version"), subprocess.check_output("java -version", stderr=subprocess.STDOUT, shell=True).split("\n"))[0].split()[2].replace("\"", "")
-if LooseVersion(jv) < LooseVersion("1.8"):
-    logger.error("VarSim requires Java 1.8 to be on the path.")
-    raise EnvironmentError("VarSim requires Java 1.8 to be on the path")
+check_java()
 
 # Make sure we can actually execute the executable
 if not args.disable_sim:

--- a/varsim.py
+++ b/varsim.py
@@ -482,7 +482,7 @@ if not args.disable_sim:
         longislnd_p = Process(target=run_shell_command, args=(longislnd_command, longislnd_stdout, longislnd_stderr))
         longislnd_p.start()
         processes.append(longislnd_p)
-        logger.info("Executing command " + " ".join(longislnd_command) + " with pid " + str(longislnd_p.pid))
+        logger.info("Executing command " + longislnd_command + " with pid " + str(longislnd_p.pid))
     else:
         raise NotImplementedError("simulation method " + args.simulator + " not implemented");
 
@@ -525,13 +525,13 @@ if not args.disable_sim:
             logger.info("Executing command " + fastq_liftover_command + " with pid " + str(liftover_p.pid))
     else:
         # liftover the read map files
-        read_maps = " ".join(map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd", "*.bed"))))
-        read_map_liftover_command = "java -server -jar %s longislnd_liftover " % args.varsim_jar.name + read_maps + " -map %s " % merged_map + " -outFile %s" % (os.path.join(args.out_dir, args.id + ".truth.map"))
+        read_maps = " ".join(map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd_sim", "*.bed"))))
+        read_map_liftover_command = "java -server -jar %s longislnd_liftover " % args.varsim_jar.name + read_maps + " -map %s " % merged_map + " -out %s" % (os.path.join(args.out_dir, args.id + ".truth.map"))
         read_map_liftover_stderr = open(os.path.join(args.log_dir, "longislnd_liftover.err"), "w")
         read_map_liftover_p = Process(target=run_shell_command, args=(read_map_liftover_command, None, read_map_liftover_stderr))
         read_map_liftover_p.start()
         processes.append(read_map_liftover_p)
-        logger.info("Executing command " + read_map_liftover_command + " with pid " + str(read_map_liftover_command.pid))
+        logger.info("Executing command " + read_map_liftover_command + " with pid " + str(read_map_liftover_p.pid))
 
     monitor_multiprocesses(processes, logger)
 

--- a/varsim.py
+++ b/varsim.py
@@ -15,7 +15,7 @@ from multiprocessing import Process
 
 VERSION = "0.6"
 MY_DIR = os.path.dirname(os.path.realpath(__file__))
-DEFAULT_VARSIMJAR = os.path.joun(MY_DIR, "VarSim.jar")
+DEFAULT_VARSIMJAR = os.path.join(MY_DIR, "VarSim.jar")
 REQUIRE_VARSIMJAR = not os.path.isfile(DEFAULT_VARSIMJAR)
 if not REQUIRE_VARSIMJAR: DEFAULT_VARSIMJAR = None
 

--- a/varsim.py
+++ b/varsim.py
@@ -17,7 +17,7 @@ VERSION = "0.6"
 MY_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_VARSIMJAR = os.path.join(MY_DIR, "VarSim.jar")
 REQUIRE_VARSIMJAR = not os.path.isfile(DEFAULT_VARSIMJAR)
-if not REQUIRE_VARSIMJAR: DEFAULT_VARSIMJAR = None
+if REQUIRE_VARSIMJAR: DEFAULT_VARSIMJAR = None
 
 def get_contigs_list(reference):
     with open("%s.fai" % (reference)) as fai_file:
@@ -53,7 +53,7 @@ def monitor_multiprocesses(processes, logger):
             logger.info("Process with pid %d finished successfully" % p.pid)
 
 
-def monitor_processes(processes, logger):
+def monitor_processes(processes):
     logger = logging.getLogger(monitor_processes.__name__)
     while processes:
         time.sleep(1)
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         logger.info("Executing command " + " ".join(rand_dgv_command) + " with pid " + str(p_rand_dgv.pid))
         processes.append(p_rand_dgv)
 
-    processes = monitor_processes(processes, logger)
+    processes = monitor_processes(processes)
 
     merged_reference = os.path.join(args.out_dir, "%s.fa" % (args.id))
     merged_truth_vcf = os.path.join(args.out_dir, "%s.truth.vcf" % (args.id))
@@ -318,7 +318,7 @@ if __name__ == "__main__":
         logger.info("Executing command " + " ".join(vcf2diploid_command) + " with pid " + str(p_vcf2diploid.pid))
         processes.append(p_vcf2diploid)
 
-        processes = monitor_processes(processes, logger)
+        processes = monitor_processes(processes)
 
         # Now concatenate the .fa from vcf2diploid
         contigs = get_contigs_list(args.reference.name)
@@ -364,7 +364,7 @@ if __name__ == "__main__":
         monitor_processes(run_vcfstats([merged_truth_vcf], args.varsim_jar.name, args.out_dir, args.log_dir))
 
     if processes:
-        processes = monitor_processes(processes, logger)
+        processes = monitor_processes(processes)
 
     merged_map = os.path.join(args.out_dir, "%s.map" % (args.id))
 

--- a/varsim.py
+++ b/varsim.py
@@ -525,7 +525,7 @@ if not args.disable_sim:
             logger.info("Executing command " + fastq_liftover_command + " with pid " + str(liftover_p.pid))
     else:
         # liftover the read map files
-        read_maps = map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd", "*.bed")))
+        read_maps = " ".join(map(lambda x: "-longislnd " + x, glob.glob(os.path.join(args.out_dir, "longislnd", "*.bed"))))
         read_map_liftover_command = "java -server -jar %s longislnd_liftover " % args.varsim_jar.name + read_maps + " -map %s " % merged_map + " -outFile %s" % (os.path.join(args.out_dir, args.id + ".truth.map"))
         read_map_liftover_stderr = open(os.path.join(args.log_dir, "longislnd_liftover.err"), "w")
         read_map_liftover_p = Process(target=run_shell_command, args=(read_map_liftover_command, None, read_map_liftover_stderr))

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -5,323 +5,234 @@
 import argparse
 import os
 import sys
-import itertools
 import subprocess
 import logging
 import time
-import signal
-from varsim import check_java, VERSION
+from varsim import VERSION, MY_DIR, DEFAULT_VARSIMJAR, REQUIRE_VARSIMJAR
+from varsim import check_java, makedirs, monitor_processes, check_executable, run_vcfstats
+
+VARSIM_PY = os.path.join(MY_DIR, "varsim.py")
+
+if __name__ == "__main__":
+
+    main_parser = argparse.ArgumentParser(description="VarSim: somatic workflow",
+                                          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    main_parser.add_argument("--out_dir", metavar="Out directory", help="Output directory",
+                             default="somatic_out")
+    main_parser.add_argument("--work_dir", metavar="Work directory", help="Work directory",
+                             default="somatic_work")
+    main_parser.add_argument("--log_dir", metavar="Log directory", help="Directory to log to",
+                             default="somatic_log")
+    main_parser.add_argument("--reference", metavar="FASTA", help="Reference genome", required=True, type=file)
+    main_parser.add_argument("--seed", metavar="INT", help="Random number seed", type=int, default=0)
+    main_parser.add_argument("--sex", metavar="Sex", help="Sex of the person (MALE/FEMALE)", required=False, type=str,
+                             choices=["MALE", "FEMALE"], default="MALE")
+    main_parser.add_argument("--id", metavar="id", help="Sample ID", required=True)
+    main_parser.add_argument("--simulator", metavar="simulator", help="Read simulator to use", required=False, type=str,
+                             choices=["art", "dwgsim"], default="art")
+    main_parser.add_argument("--simulator_executable", metavar="PATH",
+                             help="Path to the executable of the read simulator chosen"
+                             , required=True, type=file)
+    main_parser.add_argument("--varsim_jar", metavar="PATH", help="Path to VarSim.jar", type=file,
+                             default=DEFAULT_VARSIMJAR,
+                             required=REQUIRE_VARSIMJAR)
+    main_parser.add_argument("--read_length", metavar="INT", help="Length of read to simulate", default=100, type=int)
+    main_parser.add_argument("--nlanes", metavar="INT",
+                             help="Number of lanes to generate, coverage will be divided evenly over the lanes. Simulation is parallized over lanes. Each lane will have its own pair of files",
+                             default=3, type=int)
+    main_parser.add_argument("--total_coverage", metavar="FLOAT", help="Total coverage to simulate", default=1.0,
+                             type=float)
+    main_parser.add_argument("--mean_fragment_size", metavar="INT", help="Mean fragment size", default=350,
+                             type=int)
+    main_parser.add_argument("--sd_fragment_size", metavar="INT", help="Standard deviation of fragment size",
+                             default=50, type=int)
+
+    main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force bases to be ACTGN")
+    main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants")
+    main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files")
+    main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
 
 
-def get_contigs_list(reference):
-    with open("%s.fai" % (reference)) as fai_file:
-        contigs = [line.strip().split()[0] for line in fai_file.readlines()]
-    return contigs
+    input_vcf_group = main_parser.add_argument_group("Input VCFs options")
+    input_vcf_group.add_argument("--cosmic_vcf", metavar="VCF", help="COSMIC database VCF. Need to specify when random COSMIC sampling is enabled.")
+    input_vcf_group.add_argument("--normal_vcf", metavar="VCF", help="Normal VCF from previous VarSim run", required=True)
+    input_vcf_group.add_argument("--somatic_vcfs", metavar="VCF", nargs="+", help="Somatic VCF", default=[])
+    input_vcf_group.add_argument("--merge_priority", choices=["sn", "ns"], help="Priority of merging (lowest first) somatic (s) and normal truth (n).", default="sn")
 
+    pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
+    pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true", help="Disable RandVCF2VCF somatic")
+    pipeline_control_group.add_argument("--disable_vcf2diploid", action="store_true", help="Disable vcf2diploid")
+    pipeline_control_group.add_argument("--disable_sim", action="store_true", help="Disable read simulation")
 
-def makedirs(dirs):
-    for d in dirs:
-        if not os.path.exists(d):
-            os.makedirs(d)
+    # RandVCF2VCF seed num_SNP num_INS num_DEL num_MNP num_COMPLEX percent_novel min_length_lim max_length_lim reference_file file.vcf
+    rand_vcf_group = main_parser.add_argument_group("RandVCF2VCF somatic options")
+    rand_vcf_group.add_argument("--som_num_snp", metavar="INT", help="Number of somatic SNPs", default=9000, type=int)
+    rand_vcf_group.add_argument("--som_num_ins", metavar="INT", help="Number of somatic insertions", default=1000,
+                                type=int)
+    rand_vcf_group.add_argument("--som_num_del", metavar="INT", help="Number of somatic deletions", default=1000,
+                                type=int)
+    rand_vcf_group.add_argument("--som_num_mnp", metavar="INT", help="Number of somatic MNPs", default=100, type=int)
+    rand_vcf_group.add_argument("--som_num_complex", metavar="INT", help="Number of somatic complex variants",
+                                default=100, type=int)
+    # rand_vcf_group.add_argument("--som_percent_novel", metavar="percent_novel", help="Percent novel", default=0, type=float)
+    rand_vcf_group.add_argument("--som_min_length_lim", metavar="INT", help="Min length lim", default=0,
+                                type=int)
+    rand_vcf_group.add_argument("--som_max_length_lim", metavar="INT", help="Max length lim", default=49,
+                                type=int)
+    # rand_vcf_group.add_argument("--som_vcf", metavar="in_vcf", help="Input somatic variant database VCF", type=file, required=False)
+    rand_vcf_group.add_argument("--som_prop_het", metavar="FLOAT", help="Proportion of somatic heterozygous variants",
+                                default=1.0, type=float)
 
+    dwgsim_group = main_parser.add_argument_group("DWGSIM options")
+    dwgsim_group.add_argument("--dwgsim_start_e", metavar="first_base_error_rate", help="Error rate on the first base",
+                              default=0.0001, type=float)
+    dwgsim_group.add_argument("--dwgsim_end_e", metavar="last_base_error_rate", help="Error rate on the last base",
+                              default=0.0015, type=float)
+    dwgsim_group.add_argument("--dwgsim_options", help="DWGSIM command-line options", default="", required=False)
 
-my_dir = os.path.dirname(os.path.realpath(__file__))
+    art_group = main_parser.add_argument_group("ART options")
+    art_group.add_argument("--profile_1", metavar="profile_file1", help="Profile for first end", default=None, type=file)
+    art_group.add_argument("--profile_2", metavar="profile_file2", help="Profile for second end", default=None, type=file)
+    art_group.add_argument("--art_options", help="ART command-line options", default="", required=False)
 
-default_varsim_jar = os.path.join(my_dir, "VarSim.jar")
-require_varsim_jar = not os.path.isfile(default_varsim_jar)
+    args = main_parser.parse_args()
 
-if not os.path.isfile(default_varsim_jar):
-    default_varsim_jar = None
+    makedirs([args.log_dir, args.out_dir])
 
-default_varsim = os.path.join(my_dir, "varsim.py")
-require_varsim = not os.path.isfile(default_varsim)
+    FORMAT = '%(levelname)s %(asctime)-15s %(name)-20s %(message)s'
+    logging.basicConfig(filename=os.path.join(args.log_dir, "varsim.log"), filemode="w", level=logging.DEBUG, format=FORMAT)
+    logger = logging.getLogger(__name__)
 
-if not os.path.isfile(default_varsim):
-    default_varsim = None
+    check_java()
 
-main_parser = argparse.ArgumentParser(description="VarSim: somatic workflow",
-                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-main_parser.add_argument("--out_dir", metavar="Out directory", help="Output directory",
-                         default="somatic_out")
-main_parser.add_argument("--work_dir", metavar="Work directory", help="Work directory",
-                         default="somatic_work")
-main_parser.add_argument("--log_dir", metavar="Log directory", help="Directory to log to",
-                         default="somatic_log")
-main_parser.add_argument("--reference", metavar="FASTA", help="Reference genome", required=True, type=file)
-main_parser.add_argument("--seed", metavar="INT", help="Random number seed", type=int, default=0)
-main_parser.add_argument("--sex", metavar="Sex", help="Sex of the person (MALE/FEMALE)", required=False, type=str,
-                         choices=["MALE", "FEMALE"], default="MALE")
-main_parser.add_argument("--id", metavar="id", help="Sample ID", required=True)
-main_parser.add_argument("--simulator", metavar="simulator", help="Read simulator to use", required=False, type=str,
-                         choices=["art", "dwgsim"], default="art")
-main_parser.add_argument("--simulator_executable", metavar="PATH",
-                         help="Path to the executable of the read simulator chosen"
-                         , required=True, type=file)
-main_parser.add_argument("--varsim_jar", metavar="PATH", help="Path to VarSim.jar", type=file,
-                         default=default_varsim_jar,
-                         required=require_varsim_jar)
-main_parser.add_argument("--read_length", metavar="INT", help="Length of read to simulate", default=100, type=int)
-main_parser.add_argument("--nlanes", metavar="INT",
-                         help="Number of lanes to generate, coverage will be divided evenly over the lanes. Simulation is parallized over lanes. Each lane will have its own pair of files",
-                         default=3, type=int)
-main_parser.add_argument("--total_coverage", metavar="FLOAT", help="Total coverage to simulate", default=1.0,
-                         type=float)
-main_parser.add_argument("--mean_fragment_size", metavar="INT", help="Mean fragment size", default=350,
-                         type=int)
-main_parser.add_argument("--sd_fragment_size", metavar="INT", help="Standard deviation of fragment size",
-                         default=50, type=int)
+    if not args.disable_sim:
+        if not args.simulator_executable:
+            logger.error("Please specify %s binary with --simulator_executable option" % args.simulator)
+            sys.exit(os.EX_USAGE)
+        check_executable(args.simulator_executable.name)
 
-main_parser.add_argument("--force_five_base_encoding", action="store_true", help="Force bases to be ACTGN")
-main_parser.add_argument("--filter", action="store_true", help="Only use PASS variants")
-main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files")
-main_parser.add_argument("--varsim_py", metavar="PATH", help="Path to VarSim.py", type=file,
-                         default=default_varsim, required=require_varsim)
-main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
-
-
-input_vcf_group = main_parser.add_argument_group("Input VCFs options")
-input_vcf_group.add_argument("--cosmic_vcf", metavar="VCF", help="COSMIC database VCF. Need to specify when random COSMIC sampling is enabled.")
-input_vcf_group.add_argument("--normal_vcf", metavar="VCF", help="Normal VCF from previous VarSim run", required=True)
-input_vcf_group.add_argument("--somatic_vcfs", metavar="VCF", nargs="+", help="Somatic VCF", default=[])
-input_vcf_group.add_argument("--merge_priority", choices=["sn", "ns"], help="Priority of merging (lowest first) somatic (s) and normal truth (n).", default="sn")
-
-pipeline_control_group = main_parser.add_argument_group("Pipeline control options. Disable parts of the pipeline.")
-pipeline_control_group.add_argument("--disable_rand_vcf", action="store_true", help="Disable RandVCF2VCF somatic")
-pipeline_control_group.add_argument("--disable_vcf2diploid", action="store_true", help="Disable vcf2diploid")
-pipeline_control_group.add_argument("--disable_sim", action="store_true", help="Disable read simulation")
-
-# RandVCF2VCF seed num_SNP num_INS num_DEL num_MNP num_COMPLEX percent_novel min_length_lim max_length_lim reference_file file.vcf
-rand_vcf_group = main_parser.add_argument_group("RandVCF2VCF somatic options")
-rand_vcf_group.add_argument("--som_num_snp", metavar="INT", help="Number of somatic SNPs", default=9000, type=int)
-rand_vcf_group.add_argument("--som_num_ins", metavar="INT", help="Number of somatic insertions", default=1000,
-                            type=int)
-rand_vcf_group.add_argument("--som_num_del", metavar="INT", help="Number of somatic deletions", default=1000,
-                            type=int)
-rand_vcf_group.add_argument("--som_num_mnp", metavar="INT", help="Number of somatic MNPs", default=100, type=int)
-rand_vcf_group.add_argument("--som_num_complex", metavar="INT", help="Number of somatic complex variants",
-                            default=100, type=int)
-# rand_vcf_group.add_argument("--som_percent_novel", metavar="percent_novel", help="Percent novel", default=0, type=float)
-rand_vcf_group.add_argument("--som_min_length_lim", metavar="INT", help="Min length lim", default=0,
-                            type=int)
-rand_vcf_group.add_argument("--som_max_length_lim", metavar="INT", help="Max length lim", default=49,
-                            type=int)
-# rand_vcf_group.add_argument("--som_vcf", metavar="in_vcf", help="Input somatic variant database VCF", type=file, required=False)
-rand_vcf_group.add_argument("--som_prop_het", metavar="FLOAT", help="Proportion of somatic heterozygous variants",
-                            default=1.0, type=float)
-
-dwgsim_group = main_parser.add_argument_group("DWGSIM options")
-dwgsim_group.add_argument("--dwgsim_start_e", metavar="first_base_error_rate", help="Error rate on the first base",
-                          default=0.0001, type=float)
-dwgsim_group.add_argument("--dwgsim_end_e", metavar="last_base_error_rate", help="Error rate on the last base",
-                          default=0.0015, type=float)
-dwgsim_group.add_argument("--dwgsim_options", help="DWGSIM command-line options", default="", required=False)
-
-art_group = main_parser.add_argument_group("ART options")
-art_group.add_argument("--profile_1", metavar="profile_file1", help="Profile for first end", default=None, type=file)
-art_group.add_argument("--profile_2", metavar="profile_file2", help="Profile for second end", default=None, type=file)
-art_group.add_argument("--art_options", help="ART command-line options", default="", required=False)
-
-args = main_parser.parse_args()
-
-makedirs([args.log_dir, args.out_dir])
-
-FORMAT = '%(levelname)s %(asctime)-15s %(name)-20s %(message)s'
-logging.basicConfig(filename=os.path.join(args.log_dir, "varsim.log"), filemode="w", level=logging.DEBUG, format=FORMAT)
-logger = logging.getLogger(__name__)
-
-
-def run_shell_command(cmd, cmd_stdout, cmd_stderr, cmd_dir="."):
-    subproc = subprocess.Popen(cmd, stdout=cmd_stdout, stderr=cmd_stderr, cwd=cmd_dir, shell=True, preexec_fn=os.setsid)
-    retcode = subproc.wait()
-    sys.exit(retcode)
-
-
-def monitor_processes(processes):
-    logger = logging.getLogger(monitor_processes.__name__)
-    while processes:
-        time.sleep(1)
-        kill_all = False
-        processes_running = []
-        for p in processes:
-            status = p.poll()
-            if status is not None:
-                logger.info("Process %s exited with code %d" % (p.pid, status))
-                if status != 0:
-                    kill_all = True
-                    logger.error("Process %s failed. Will kill the remaining processes." % (p.pid))
-            else:
-                processes_running.append(p)
-        if kill_all:
-            for p in processes:
-                status = p.poll()
-                if status is None:
-                    try:
-                        os.killpg(p.pid, signal.SIGTERM)
-                    except OSError, e:
-                        try:
-                            p.terminate()
-                        except OSError, ex:
-                            logger.error("Could not kill the process %d\n" % p.pid)
-            sys.exit(1)
-        processes = processes_running
-    return []
-
-
-def check_executable(fpath):
-    logger = logging.getLogger(check_executable.__name__)
-    if not os.path.isfile(fpath):
-        logger.error("File %s does not exist" % fpath)
-        sys.exit(os.EX_NOINPUT)
-    if not os.access(fpath, os.X_OK):
-        logger.error("File %s is not executable" % fpath)
-        sys.exit(os.EX_NOINPUT)
-
-
-def run_vcfstats(vcfs, varsim_jar, out_dir, log_dir):
-    logger = logging.getLogger(run_vcfstats.__name__)
     processes = []
-    for in_vcf in vcfs:
-        out_prefix = os.path.basename(in_vcf)
-        vcfstats_stdout = open(os.path.join(out_dir, "%s.stats" % (out_prefix)), "w")
-        vcfstats_stderr = open(os.path.join(log_dir, "%s.vcfstats.err" % (out_prefix)), "w")
-        vcfstats_command = ["java", "-Xmx1g", "-Xms1g", "-jar", os.path.realpath(varsim_jar), "vcfstats", "-vcf",
-                        in_vcf]
-        p_vcfstats = subprocess.Popen(vcfstats_command, stdout=vcfstats_stdout, stderr=vcfstats_stderr)
-        logger.info("Executing command " + " ".join(vcfstats_command) + " with pid " + str(p_vcfstats.pid))
-        processes.append(p_vcfstats)
-    return processes
 
+    t_s = time.time()
 
-check_java()
+    cosmic_sampled_vcfs = []
+    if not args.disable_rand_vcf:
+        if not args.cosmic_vcf:
+            logger.error("COSMIC database VCF not specified using --cosmic_vcf")
+            sys.exit(os.EX_USAGE)
+        rand_vcf_stdout = open(os.path.join(args.out_dir, "random.cosmic.vcf"), "w")
+        rand_vcf_stderr = open(os.path.join(args.log_dir, "random.cosmic.err"), "w")
+        cosmic_sampled_vcfs = [rand_vcf_stdout.name]
 
-if not args.disable_sim:
-    if not args.simulator_executable:
-        logger.error("Please specify %s binary with --simulator_executable option" % args.simulator)
-        sys.exit(os.EX_USAGE)
-    check_executable(args.simulator_executable.name)
+        # Not able to support novel yet for COSMIC variants
+        rand_vcf_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "randvcf2vcf", "-seed", str(args.seed),
+                            "-num_snp", str(args.som_num_snp),
+                            "-num_ins", str(args.som_num_ins),
+                            "-num_del", str(args.som_num_del),
+                            "-num_mnp", str(args.som_num_mnp),
+                            "-num_complex", str(args.som_num_complex),
+                            "-min_len", str(args.som_min_length_lim),
+                            "-max_len", str(args.som_max_length_lim),
+                            "-ref", os.path.realpath(args.reference.name),
+                            "-prop_het", str(args.som_prop_het),
+                            "-vcf", os.path.realpath(args.cosmic_vcf)]
 
-processes = []
+        p_rand_vcf = subprocess.Popen(rand_vcf_command, stdout=rand_vcf_stdout, stderr=rand_vcf_stderr)
+        logger.info("Executing command " + " ".join(rand_vcf_command) + " with pid " + str(p_rand_vcf.pid))
+        processes.append(p_rand_vcf)
 
-t_s = time.time()
+    processes = monitor_processes(processes)
 
-cosmic_sampled_vcfs = []
-if not args.disable_rand_vcf:
-    if not args.cosmic_vcf:
-        logger.error("COSMIC database VCF not specified using --cosmic_vcf")
-        sys.exit(os.EX_USAGE)
-    rand_vcf_stdout = open(os.path.join(args.out_dir, "random.cosmic.vcf"), "w")
-    rand_vcf_stderr = open(os.path.join(args.log_dir, "random.cosmic.err"), "w")
-    cosmic_sampled_vcfs = [rand_vcf_stdout.name]
+    normal_vcfs = [args.normal_vcf]
+    somatic_vcfs = cosmic_sampled_vcfs + args.somatic_vcfs
+    fixed_somatic_vcfs = []
+    if somatic_vcfs:
+        vcfs_dir = os.path.join(args.out_dir, "somatic_vcfs")
+        makedirs([vcfs_dir])
+        count = 0
+        for index, vcf in enumerate(somatic_vcfs):
+            copied_vcf = os.path.join(vcfs_dir, "%d.vcf" % index)
+            logger.info("Copying somatic VCF %s to %s and adding VARSIMSOMATIC id to entries if missing" % (vcf, copied_vcf))
+            with open(vcf, "r") as vcf_fd, open(copied_vcf, "w") as copied_vcf_fd:
+                for line in vcf_fd:
+                    if line.startswith("#"):
+                        copied_vcf_fd.write(line)
+                    else:
+                        line_fields = line.split("\t")
+                        line_fields[2] = ("VARSIMSOMATIC%d" % count) if line_fields[2] == "." else ("%s,VARSIMSOMATIC%d" % (line_fields[2], count))
+                        copied_vcf_fd.write("\t".join(line_fields))
+                        count += 1
+            fixed_somatic_vcfs.append(copied_vcf)
 
-    # Not able to support novel yet for COSMIC variants
-    rand_vcf_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "randvcf2vcf", "-seed", str(args.seed),
-                        "-num_snp", str(args.som_num_snp),
-                        "-num_ins", str(args.som_num_ins),
-                        "-num_del", str(args.som_num_del),
-                        "-num_mnp", str(args.som_num_mnp),
-                        "-num_complex", str(args.som_num_complex),
-                        "-min_len", str(args.som_min_length_lim),
-                        "-max_len", str(args.som_max_length_lim),
-                        "-ref", os.path.realpath(args.reference.name),
-                        "-prop_het", str(args.som_prop_het),
-                        "-vcf", os.path.realpath(args.cosmic_vcf)]
+    vcf_files = (fixed_somatic_vcfs + normal_vcfs) if args.merge_priority == "sn" else (normal_vcfs + fixed_somatic_vcfs)
+    vcf_files = map(os.path.realpath, filter(None, vcf_files))
 
-    p_rand_vcf = subprocess.Popen(rand_vcf_command, stdout=rand_vcf_stdout, stderr=rand_vcf_stderr)
-    logger.info("Executing command " + " ".join(rand_vcf_command) + " with pid " + str(p_rand_vcf.pid))
-    processes.append(p_rand_vcf)
+    processes = run_vcfstats(vcf_files, args.varsim_jar.name, args.out_dir, args.log_dir)
 
-processes = monitor_processes(processes)
+    # Run VarSim
+    varsim_stdout = open(os.path.join(args.log_dir, "som_varsim.out"), "w")
+    varsim_stderr = open(os.path.join(args.log_dir, "som_varsim.log"), "w")
 
-normal_vcfs = [args.normal_vcf]
-somatic_vcfs = cosmic_sampled_vcfs + args.somatic_vcfs
-fixed_somatic_vcfs = []
-if somatic_vcfs:
-    vcfs_dir = os.path.join(args.out_dir, "somatic_vcfs")
-    makedirs([vcfs_dir])
-    count = 0
-    for index, vcf in enumerate(somatic_vcfs):
-        copied_vcf = os.path.join(vcfs_dir, "%d.vcf" % index)
-        logger.info("Copying somatic VCF %s to %s and adding VARSIMSOMATIC id to entries if missing" % (vcf, copied_vcf))
-        with open(vcf, "r") as vcf_fd, open(copied_vcf, "w") as copied_vcf_fd:
-            for line in vcf_fd:
-                if line.startswith("#"):
-                    copied_vcf_fd.write(line)
-                else:
-                    line_fields = line.split("\t")
-                    line_fields[2] = ("VARSIMSOMATIC%d" % count) if line_fields[2] == "." else ("%s,VARSIMSOMATIC%d" % (line_fields[2], count))
-                    copied_vcf_fd.write("\t".join(line_fields))
-                    count += 1
-        fixed_somatic_vcfs.append(copied_vcf)
-            
-vcf_files = (fixed_somatic_vcfs + normal_vcfs) if args.merge_priority == "sn" else (normal_vcfs + fixed_somatic_vcfs)
-vcf_files = map(os.path.realpath, filter(None, vcf_files))
+    vcf_arg_list = ["--vcfs"] + vcf_files
 
-processes = run_vcfstats(vcf_files, args.varsim_jar.name, args.out_dir, args.log_dir)
+    # need to fix the store true ones
+    filter_arg_list = ["--filter"] if args.filter else []
+    disable_sim_arg_list = ["--disable_sim"] if args.disable_sim else []
+    force_five_base_encoding_arg_list = ["--force_five_base_encoding"] if args.force_five_base_encoding else []
+    keep_temp_arg_list = ["--keep_temp"] if args.keep_temp else []
+    profile_1_arg_list = ["--profile_1", args.profile_1.name] if args.profile_1 is not None else []
+    profile_2_arg_list = ["--profile_2", args.profile_2.name] if args.profile_2 is not None else []
+    other_varsim_opts = []
+    if args.simulator == "dwgsim":
+        other_varsim_opts = ["--dwgsim_start_e", str(args.dwgsim_start_e), "--dwgsim_end_e", str(args.dwgsim_end_e)]
+        if args.dwgsim_options: other_varsim_opts += ["--dwgsim_options", str(args.dwgsim_options)]
+    elif args.simulator == "art" and args.art_options:
+        other_varsim_opts += ["--art_options", args.art_options]
 
-# Run VarSim 
-varsim_stdout = open(os.path.join(args.log_dir, "som_varsim.out"), "w")
-varsim_stderr = open(os.path.join(args.log_dir, "som_varsim.log"), "w")
+    varsim_command = ["python", os.path.realpath(VARSIM_PY),
+                      "--out_dir", str(os.path.realpath(args.out_dir)),
+                      "--work_dir", str(os.path.realpath(args.work_dir)),
+                      "--log_dir", str(os.path.realpath(os.path.join(args.log_dir, "varsim"))),
+                      "--reference", str(os.path.realpath(args.reference.name)),
+                      "--seed", str(args.seed),
+                      "--sex", str(args.sex),
+                      "--id", str(args.id),
+                      "--simulator", str(args.simulator),
+                      "--simulator_executable", str(args.simulator_executable.name),
+                      "--varsim_jar", str(os.path.realpath(args.varsim_jar.name)),
+                      "--read_length", str(args.read_length),
+                      "--nlanes", str(args.nlanes),
+                      "--total_coverage", str(args.total_coverage),
+                      "--mean_fragment_size", str(args.mean_fragment_size),
+                      "--sd_fragment_size", str(args.sd_fragment_size),
+                      "--disable_rand_vcf",
+                      "--disable_rand_dgv"] + other_varsim_opts + vcf_arg_list + filter_arg_list + disable_sim_arg_list \
+                     + force_five_base_encoding_arg_list + keep_temp_arg_list + profile_1_arg_list + profile_2_arg_list
+    varsim_command = " ".join(varsim_command)
+    p_varsim = subprocess.Popen(varsim_command, stdout=varsim_stdout, stderr=varsim_stderr, shell=True)
+    logger.info("Executing command " + varsim_command + " with pid " + str(p_varsim.pid))
+    processes.append(p_varsim)
 
-vcf_arg_list = ["--vcfs"] + vcf_files
+    processes = monitor_processes(processes)
 
-# need to fix the store true ones
-filter_arg_list = ["--filter"] if args.filter else []
-disable_sim_arg_list = ["--disable_sim"] if args.disable_sim else []
-force_five_base_encoding_arg_list = ["--force_five_base_encoding"] if args.force_five_base_encoding else []
-keep_temp_arg_list = ["--keep_temp"] if args.keep_temp else []
-profile_1_arg_list = ["--profile_1", args.profile_1.name] if args.profile_1 is not None else []
-profile_2_arg_list = ["--profile_2", args.profile_2.name] if args.profile_2 is not None else []
-other_varsim_opts = []
-if args.simulator == "dwgsim":
-    other_varsim_opts = ["--dwgsim_start_e", str(args.dwgsim_start_e), "--dwgsim_end_e", str(args.dwgsim_end_e)]
-    if args.dwgsim_options: other_varsim_opts += ["--dwgsim_options", str(args.dwgsim_options)]
-elif args.simulator == "art" and args.art_options:
-    other_varsim_opts += ["--art_options", args.art_options]
+    # Split the tumor truth VCF into normal variants and somatic variants
+    tumor_vcf = os.path.realpath(os.path.join(args.out_dir, "%s.truth.vcf" % args.id))
+    normal_vcf = os.path.join(args.out_dir, "%s_norm.vcf" % args.id)
+    somatic_vcf = os.path.join(args.out_dir, "%s_somatic.vcf" % args.id)
+    logger.info("Splitting the truth VCF %s into normal and somatic VCFs" % tumor_vcf)
+    with open(tumor_vcf, "r") as tumor_truth_fd, \
+        open(normal_vcf, "w") as normal_vcf_fd, \
+        open(somatic_vcf, "w") as somatic_vcf_fd:
+        for line in tumor_truth_fd:
+            if line.startswith("#"):
+                somatic_vcf_fd.write(line)
+                normal_vcf_fd.write(line)
+                continue
+            if line.find("VARSIMSOMATIC") >= 0:
+                somatic_vcf_fd.write(line)
+            else:
+                normal_vcf_fd.write(line)
 
-varsim_command = ["python", os.path.realpath(args.varsim_py.name),
-                  "--out_dir", str(os.path.realpath(args.out_dir)),
-                  "--work_dir", str(os.path.realpath(args.work_dir)),
-                  "--log_dir", str(os.path.realpath(os.path.join(args.log_dir, "varsim"))),
-                  "--reference", str(os.path.realpath(args.reference.name)),
-                  "--seed", str(args.seed),
-                  "--sex", str(args.sex),
-                  "--id", str(args.id),
-                  "--simulator", str(args.simulator),
-                  "--simulator_executable", str(args.simulator_executable.name),
-                  "--varsim_jar", str(os.path.realpath(args.varsim_jar.name)),
-                  "--read_length", str(args.read_length),
-                  "--nlanes", str(args.nlanes),
-                  "--total_coverage", str(args.total_coverage),
-                  "--mean_fragment_size", str(args.mean_fragment_size),
-                  "--sd_fragment_size", str(args.sd_fragment_size),
-                  "--disable_rand_vcf",
-                  "--disable_rand_dgv"] + other_varsim_opts + vcf_arg_list + filter_arg_list + disable_sim_arg_list \
-                 + force_five_base_encoding_arg_list + keep_temp_arg_list + profile_1_arg_list + profile_2_arg_list
-varsim_command = " ".join(varsim_command)
-p_varsim = subprocess.Popen(varsim_command, stdout=varsim_stdout, stderr=varsim_stderr, shell=True)
-logger.info("Executing command " + varsim_command + " with pid " + str(p_varsim.pid))
-processes.append(p_varsim)
+    monitor_processes(run_vcfstats([normal_vcf, somatic_vcf], args.varsim_jar.name, args.out_dir, args.log_dir))
 
-processes = monitor_processes(processes)
-
-# Split the tumor truth VCF into normal variants and somatic variants
-tumor_vcf = os.path.realpath(os.path.join(args.out_dir, "%s.truth.vcf" % args.id))
-normal_vcf = os.path.join(args.out_dir, "%s_norm.vcf" % args.id)
-somatic_vcf = os.path.join(args.out_dir, "%s_somatic.vcf" % args.id)
-logger.info("Splitting the truth VCF %s into normal and somatic VCFs" % tumor_vcf)
-with open(tumor_vcf, "r") as tumor_truth_fd, \
-    open(normal_vcf, "w") as normal_vcf_fd, \
-    open(somatic_vcf, "w") as somatic_vcf_fd:
-    for line in tumor_truth_fd:
-        if line.startswith("#"):
-            somatic_vcf_fd.write(line)
-            normal_vcf_fd.write(line)
-            continue
-        if line.find("VARSIMSOMATIC") >= 0:
-            somatic_vcf_fd.write(line)
-        else:
-            normal_vcf_fd.write(line)
-
-monitor_processes(run_vcfstats([normal_vcf, somatic_vcf], args.varsim_jar.name, args.out_dir, args.log_dir))
-
-logger.info("Done! (%g hours)" % ((time.time() - t_s) / 3600.0))
+    logger.info("Done! (%g hours)" % ((time.time() - t_s) / 3600.0))

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -264,8 +264,15 @@ filter_arg_list = ["--filter"] if args.filter else []
 disable_sim_arg_list = ["--disable_sim"] if args.disable_sim else []
 force_five_base_encoding_arg_list = ["--force_five_base_encoding"] if args.force_five_base_encoding else []
 keep_temp_arg_list = ["--keep_temp"] if args.keep_temp else []
-profile_1_arg_list = ["--profile_1", args.profile_1] if args.profile_1 is not None else []
-profile_2_arg_list = ["--profile_2", args.profile_2] if args.profile_2 is not None else []
+profile_1_arg_list = ["--profile_1", args.profile_1.name] if args.profile_1 is not None else []
+profile_2_arg_list = ["--profile_2", args.profile_2.name] if args.profile_2 is not None else []
+other_varsim_opts = []
+if args.simulator == "dwgsim":
+    other_varsim_opts = ["--dwgsim_start_e", str(args.dwgsim_start_e), "--dwgsim_end_e", str(args.dwgsim_end_e)]
+    if args.dwgsim_options: other_varsim_opts += ["--dwgsim_options", str(args.dwgsim_options)]
+elif args.simulator == "art" and args.art_options:
+    other_varsim_opts += ["--art_options", args.art_options]
+
 varsim_command = ["python", os.path.realpath(args.varsim_py.name),
                   "--out_dir", str(os.path.realpath(args.out_dir)),
                   "--work_dir", str(os.path.realpath(args.work_dir)),
@@ -282,15 +289,12 @@ varsim_command = ["python", os.path.realpath(args.varsim_py.name),
                   "--total_coverage", str(args.total_coverage),
                   "--mean_fragment_size", str(args.mean_fragment_size),
                   "--sd_fragment_size", str(args.sd_fragment_size),
-                  "--dwgsim_start_e", str(args.dwgsim_start_e),
-                  "--dwgsim_end_e", str(args.dwgsim_end_e),
-                  "--dwgsim_options", str(args.dwgsim_options),
-                  "--art_options", str(args.art_options),
                   "--disable_rand_vcf",
-                  "--disable_rand_dgv"] + vcf_arg_list + filter_arg_list + disable_sim_arg_list \
+                  "--disable_rand_dgv"] + other_varsim_opts + vcf_arg_list + filter_arg_list + disable_sim_arg_list \
                  + force_five_base_encoding_arg_list + keep_temp_arg_list + profile_1_arg_list + profile_2_arg_list
-p_varsim = subprocess.Popen(varsim_command, stdout=varsim_stdout, stderr=varsim_stderr)
-logger.info("Executing command " + " ".join(varsim_command) + " with pid " + str(p_varsim.pid))
+varsim_command = " ".join(varsim_command)
+p_varsim = subprocess.Popen(varsim_command, stdout=varsim_stdout, stderr=varsim_stderr, shell=True)
+logger.info("Executing command " + varsim_command + " with pid " + str(p_varsim.pid))
 processes.append(p_varsim)
 
 processes = monitor_processes(processes)

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -10,7 +10,7 @@ import subprocess
 import logging
 import time
 import signal
-from varsim import check_java
+from varsim import check_java, VERSION
 
 
 def get_contigs_list(reference):
@@ -76,6 +76,8 @@ main_parser.add_argument("--filter", action="store_true", help="Only use PASS va
 main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files")
 main_parser.add_argument("--varsim_py", metavar="PATH", help="Path to VarSim.py", type=file,
                          default=default_varsim, required=require_varsim)
+main_parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
+
 
 input_vcf_group = main_parser.add_argument_group("Input VCFs options")
 input_vcf_group.add_argument("--cosmic_vcf", metavar="VCF", help="COSMIC database VCF. Need to specify when random COSMIC sampling is enabled.")

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -76,7 +76,7 @@ main_parser.add_argument("--filter", action="store_true", help="Only use PASS va
 main_parser.add_argument("--keep_temp", action="store_true", help="Keep temporary files")
 main_parser.add_argument("--varsim_py", metavar="PATH", help="Path to VarSim.py", type=file,
                          default=default_varsim, required=require_varsim)
-main_parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
+main_parser.add_argument('--version', action='version', version='VarSim: %(prog)s ' + VERSION)
 
 
 input_vcf_group = main_parser.add_argument_group("Input VCFs options")

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -10,6 +10,7 @@ import subprocess
 import logging
 import time
 import signal
+from varsim import check_java
 
 
 def get_contigs_list(reference):
@@ -189,6 +190,8 @@ def run_vcfstats(vcfs, varsim_jar, out_dir, log_dir):
     return processes
 
 
+check_java()
+
 if not args.disable_sim:
     if not args.simulator_executable:
         logger.error("Please specify %s binary with --simulator_executable option" % args.simulator)
@@ -208,13 +211,13 @@ if not args.disable_rand_vcf:
     rand_vcf_stderr = open(os.path.join(args.log_dir, "random.cosmic.err"), "w")
     cosmic_sampled_vcfs = [rand_vcf_stdout.name]
 
+    # Not able to support novel yet for COSMIC variants
     rand_vcf_command = ["java", "-jar", os.path.realpath(args.varsim_jar.name), "randvcf2vcf", "-seed", str(args.seed),
                         "-num_snp", str(args.som_num_snp),
                         "-num_ins", str(args.som_num_ins),
                         "-num_del", str(args.som_num_del),
                         "-num_mnp", str(args.som_num_mnp),
                         "-num_complex", str(args.som_num_complex),
-                        # "-novel", str(args.som_percent_novel), # Not able to support novel yet (COS)
                         "-min_len", str(args.som_min_length_lim),
                         "-max_len", str(args.som_max_length_lim),
                         "-ref", os.path.realpath(args.reference.name),


### PR DESCRIPTION
Read simulators may not encode true alignment information in the read names. Instead, they may output the true locations in a read map file which has maps from read names to alignment locations. 