### PR TITLE
fix VCF header

### DIFF
--- a/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
@@ -841,17 +841,22 @@ public class VCF2diploid {
                 /*
                 SVLEN is for alternative allele in truth VCF
                  */
-                "##INFO=<ID=SVLEN,Number=A,Type=Integer,Description=\"Length of variant\">\n" +
+                "##INFO=<ID=SVLEN,Number=.,Type=Integer,Description=\"Length of variant\">\n" +
                 "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of structural variant\">\n" +
                 /*if POS2<=END2, then another sequence is inserted at positive strand
                 if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion)
                  */
                 "##INFO=<ID=POS2,Number=A,Type=Integer,Description=\"1-based Start position of source sequence\">\n" +
                 "##INFO=<ID=END2,Number=A,Type=Integer,Description=\"1-based End position of source sequence\">\n" +
+                "##INFO=<ID=END,Number=1,Type=Integer,Description=\"1-based End position of sink sequence\">\n" +
                 "##INFO=<ID=CHR2,Number=A,Type=String,Description=\"Chromosome of source sequence\">\n" +
                 "##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description=\"Subtype of translocation event:" +
                 " source sequence deleted (REJECT); source sequence accepted (ACCEPT).\">\n" +
                 "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n" +
+                /*CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN values
+                here we changed it to String to allow such behavior.
+                 */
+                "##FORMAT=<ID=CN,Number=1,Type=String,Description=\"Copy number genotype. Different copy numbers do not imply same genotypes.\">\n" +
                 "##ALT=<ID=DEL,Description=\"Deletion\">\n" +
                 "##ALT=<ID=DEL:ME:ALU,Description=\"Deletion of ALU element\">\n" +
                 "##ALT=<ID=DEL:ME:L1,Description=\"Deletion of L1 element\">\n" +

--- a/src/test/resources/DeletionTest/oneDeletionTest.vcf
+++ b/src/test/resources/DeletionTest/oneDeletionTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/DeletionTest/oneDeletionTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/DuplicationTest/oneDuplicationTest.vcf
+++ b/src/test/resources/DuplicationTest/oneDuplicationTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/DuplicationTest/oneDuplicationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/InsertionTest/oneInsertionTest.vcf
+++ b/src/test/resources/InsertionTest/oneInsertionTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/InsertionTest/oneInsertionTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/InversionTest/oneInversionTest.vcf
+++ b/src/test/resources/InversionTest/oneInversionTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/InversionTest/oneInversionTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/MNPTest/oneMNPTest.vcf
+++ b/src/test/resources/MNPTest/oneMNPTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/MNPTest/oneMNPTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/MNPTest/oneMNPTestExpected.vcf
+++ b/src/test/resources/MNPTest/oneMNPTestExpected.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/MNPTest/oneMNPTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/MixedTest/oneMixedTest.vcf
+++ b/src/test/resources/MixedTest/oneMixedTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/MixedTest/oneMixedTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/SNPTest/oneSNPTest.vcf
+++ b/src/test/resources/SNPTest/oneSNPTest.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/SNPTest/oneSNPTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterHomologousChromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationInterchromosomalWithInversion.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.vcf
+++ b/src/test/resources/TranslocationTest/BalancedNonReciprocalTranslocationTest/balancedNonReciprocalTranslocationIntrachromosomalWithInversion.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationInterchromosomalWithInversion.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.vcf
+++ b/src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/balancedReciprocalTranslocationIntrachromosomalWithInversion.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/BalancedReciprocalTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocationWithInversion/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocation/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainIntrachromosomalTranslocationWithInversion/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedGainTranslocationTest/UnbalancedGainInterchromosomalTranslocation/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationInterchromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.expected.1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.expected.1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.expected.2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.expected.2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/unbalancedTranslocationIntrachromosomal.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationTest/twelveTranslocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossInterchromosomalTranslocationWithInversion/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/translocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/1.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/1.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/2.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/2.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/reference.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/input.vcf
+++ b/src/test/resources/TranslocationTest/UnbalancedLossTranslocationWithInversionTest/UnbalancedLossIntrachromosomalTranslocationWithInversion/input.vcf
@@ -1,12 +1,14 @@
 ##fileformat=VCFv4.1
 ##reference=src/test/resources/TranslocationTest/translocationTest.fa
-##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Length of variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##INFO=<ID=POS2,Number=A,Type=Integer,Description="1-based Start position of source sequence">
 ##INFO=<ID=END2,Number=A,Type=Integer,Description="1-based End position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based End position of sink sequence">
 ##INFO=<ID=CHR2,Number=A,Type=String,Description="Chromosome of source sequence">
 ##INFO=<ID=TRASUBTYPE,Number=A,Type=String,Description="Subtype of translocation event: source sequence deleted (REJECT); source sequence accepted (ACCEPT).">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest1/compare.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest1/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest1/truth.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest1/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest2/compare.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest2/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest2/truth.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest2/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest3/compare.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest3/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/canonicalizationTest3/truth.vcf
+++ b/src/test/resources/validationTest/canonicalizationTest3/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/differentPaddingTest/compare.vcf
+++ b/src/test/resources/validationTest/differentPaddingTest/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/differentPaddingTest/truth.vcf
+++ b/src/test/resources/validationTest/differentPaddingTest/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/genotypeTest1/compare.vcf
+++ b/src/test/resources/validationTest/genotypeTest1/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/genotypeTest1/truth.vcf
+++ b/src/test/resources/validationTest/genotypeTest1/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/genotypeTest2/compare.vcf
+++ b/src/test/resources/validationTest/genotypeTest2/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/genotypeTest2/truth.vcf
+++ b/src/test/resources/validationTest/genotypeTest2/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/identicalTest/compare.vcf
+++ b/src/test/resources/validationTest/identicalTest/compare.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">

--- a/src/test/resources/validationTest/identicalTest/truth.vcf
+++ b/src/test/resources/validationTest/identicalTest/truth.vcf
@@ -3,6 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of variant">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype. Different copy numbers do not imply same genotypes.">
 ##ALT=<ID=DEL,Description="Deletion">
 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
 ##ALT=<ID=DEL:ME:L1,Description="Deletion of L1 element">


### PR DESCRIPTION
- [x] [RES-411](https://binatechnologies.atlassian.net/browse/RES-411)
- [x] Blocking PRs: ADD HERE IF ANY
* People
  - [x] Reviewers (>=1): @marghoob 
  - [x] Merger (>=1): @marghoob 
  - [x] FYI: ADD HERE IF ANY
- [x] Release note (if needed)
- [x] No code copied from outside Bina & all library dependency changes reported to Greg
- [x] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

- make SVLEN count to be . to be consistent with VCFspec 4.1
- added CN description in header. However, its type is String for now to accomodate more than one CN values
- added END to VCF header
- keep 1 SVLEN value for each ALT allele
- ignore vcftools' warning about duplicate ALT allele