### PR TITLE
Bugfixes 0.8.0

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -4,12 +4,7 @@ set -x
 
 b37_source="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
 dbsnp_source="ftp://ftp.ncbi.nih.gov/snp/organisms/human_9606_b147_GRCh37p13/VCF/All_20160601.vcf.gz"
-varsim_version="0.7.7"
 samtools_version="1.3.1"
-
-# Download varsim
-wget https://github.com/bioinform/varsim/releases/download/v$varsim_version/varsim-$varsim_version.tar.gz
-tar xfz varsim-$varsim_version.tar.gz
 
 # Download reference and variant databases 
 wget $b37_source -O - | gunzip -c > hs37d5.fa

--- a/src/main/java/com/bina/varsim/tools/simulation/RandVCFgenerator.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/RandVCFgenerator.java
@@ -117,7 +117,7 @@ abstract public class RandVCFgenerator extends VarSimTool {
                 int len = alt.length();
                 byte newSeq[] = new byte[len];
                 // randomly duplicate insertion sequence if it is small
-                final int segLen = (len > insertSeq.length) ? (int) Math.ceil(insertSeq.length / NSEGMENTS) : len;
+                final int segLen = (len >= insertSeq.length) ? (int) Math.ceil(insertSeq.length / NSEGMENTS) : len;
                 for (int i = 0; i < len; i += segLen) {
                     // choose random start loc
                     int randStart = rand.nextInt(insertSeq.length - segLen);

--- a/varsim.py
+++ b/varsim.py
@@ -455,7 +455,7 @@ def varsim_main(reference,
         elif simulator == "art":
             for i in xrange(nlanes):
                 simulator_command = "{} {} -i {} -f {} -rs {} -o {}".format(simulator_exe, simulator_options, merged_reference, coverage_per_lane, seed + i, os.path.join(out_dir, "simulated.lane%d.read" % (i)))
-                simulator_commands_files.append((art_command, os.path.join(log_dir, "art.lane%d.out" % (i)), os.path.join(log_dir, "art.lane%d.err" % (i))))
+                simulator_commands_files.append((simulator_command, os.path.join(log_dir, "art.lane%d.out" % (i)), os.path.join(log_dir, "art.lane%d.err" % (i))))
         else: # simulator == "longislnd":
             simulator_command = "{} {} --coverage {} --out {} --fasta {}".format(simulator_exe, simulator_options, total_coverage * 0.5, os.path.join(out_dir, "longislnd_sim"), merged_reference)
             simulator_commands_files.append((simulator_command, os.path.join(log_dir, "longislnd.out"), os.path.join(log_dir, "longislnd.err")))

--- a/varsim_somatic.py
+++ b/varsim_somatic.py
@@ -9,7 +9,7 @@ import subprocess
 import logging
 import time
 from varsim import MY_DIR, VARSIMJAR, DEFAULT_VARSIMJAR, REQUIRE_VARSIMJAR
-from varsim import check_java, makedirs, monitor_processes, check_executable, run_vcfstats, run_randvcf, get_version
+from varsim import check_java, makedirs, monitor_processes, check_executable, run_vcfstats, run_randvcf, get_version, RandVCFOptions
 
 VARSIM_PY = os.path.join(MY_DIR, "varsim.py")
 
@@ -126,7 +126,7 @@ def varsim_somatic_main():
         cosmic_sampled_vcfs = [rand_vcf_stdout.name]
 
         # Not able to support novel yet for COSMIC variants
-        randvcf_options = RandVCFOptions(args.som_num_snp, args.som_num_ins, args.som_num_del, args.som_num_mnp, args.som_num_comples, 0, args.som_min_length_lim, args.som_max_length_lim, args.som_prop_het)
+        randvcf_options = RandVCFOptions(args.som_num_snp, args.som_num_ins, args.som_num_del, args.som_num_mnp, args.som_num_complex, 0, args.som_min_length_lim, args.som_max_length_lim, args.som_prop_het)
         monitor_processes([run_randvcf(os.path.realpath(args.cosmic_vcf), rand_vcf_stdout, rand_vcf_stderr, args.seed, args.sex, randvcf_options, args.reference.name)])
 
     normal_vcfs = [args.normal_vcf]


### PR DESCRIPTION
- [x] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [x] Blocking PRs: ADD HERE IF ANY
* People
  - [x] Reviewers (>=1): 
  - [x] Merger (>=1): ADD HERE
  - [x] FYI: ADD HERE IF ANY
- [x] Release note (if needed)
- [x] No code copied from outside Bina 
- [x] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [x] PR labels, milestones & assignees

# Summary

* remove re-downloading of varsim package in quickstart (assume `quickstart.sh` will be downloaded with matching code)
* fix fill seq length bug in randvcf generation
* fix bugs related to new interface in `varsim.py`
