### PR TITLE
remove wiggle for small var

### DIFF
--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -68,7 +68,7 @@ public class VCFcompare extends VarSimTool {
     @Option(name = "-over", usage = "Reciprocal overlap ratio allowance in validation [" + OVERLAP_ARG + "]")
     double overlapRatio = OVERLAP_ARG;
 
-    @Option(name = "-wig", usage = "Wiggle allowance in validation [" + WIGGLE_ARG + "]")
+    @Option(name = "-wig", usage = "Wiggle allowance in validation [" + WIGGLE_ARG + "]. Note that it is only used for SV")
     int wiggle = WIGGLE_ARG;
 
     @Option(name = "-ignore_ins_len", usage = "Ignores insertion length when comparing")
@@ -1508,7 +1508,7 @@ public class VCFcompare extends VarSimTool {
             } else {
                 // Non-SNPs
                 if ((type ==  VariantType.Insertion || type == VariantType.Deletion || type == VariantType.Complex ) &&
-                    intervalForCompare.right - intervalForCompare.left < Constant.SVLEN) {
+                    intervalForCompare.right - intervalForCompare.left + 1 < Constant.SVLEN) {
                   wiggle = 0;
                 }
                 SimpleInterval1D intervalForCompareWithWiggle = new SimpleInterval1D(intervalForCompare.left - wiggle, intervalForCompare.right + wiggle);

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -1507,6 +1507,10 @@ public class VCFcompare extends VarSimTool {
                 }
             } else {
                 // Non-SNPs
+                if ((type ==  VariantType.Insertion || type == VariantType.Deletion || type == VariantType.Complex ) &&
+                    intervalForCompare.right - intervalForCompare.left < Constant.SVLEN) {
+                  wiggle = 0;
+                }
                 SimpleInterval1D intervalForCompareWithWiggle = new SimpleInterval1D(intervalForCompare.left - wiggle, intervalForCompare.right + wiggle);
                 Iterable<ValueInterval1D<Variant>> overlaps = trueVariantIntervalTree.getOverlaps(chr, intervalForCompareWithWiggle);
 


### PR DESCRIPTION
Try to remove wiggle for comparing small var. But two tests failed. 
Failed tests:   breakendEvaluationDifferentInsertionsSucceedWithLargeWiggle(com.bina.varsim.tools.evaluation.VCFCompareTest)
  breakendEvaluationNonReciprocalBalancedWithLargeWiggle(com.bina.varsim.tools.evaluation.VCFCompareTest)
