### PR TITLE
Fix complex variant 

### DIFF
--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -96,6 +96,9 @@ class VCFComparator(object):
         return self.fn
 
 class VarSimVCFComparator(VCFComparator):
+    def __init__(self, prefix, true_vcf, reference, regions, sample, vcfs, exclude_filtered, disallow_partial_fp, match_geno, log_to_file, opts):
+        VCFComparator.__init__(self, prefix, true_vcf, reference, regions, sample, vcfs, exclude_filtered, match_geno, log_to_file, opts)
+        self.disallow_partial_fp = disallow_partial_fp
     def get_tp_predict(self):
         '''
         varsim does not generate TP based off of predictions
@@ -123,6 +126,8 @@ class VarSimVCFComparator(VCFComparator):
         if self.regions:
             cmd.append('-bed')
             cmd.append(self.regions)
+        if self.disallow_partial_fp:
+            cmd.append('-disallow_partial_fp')
         if self.opts:
             cmd.append(self.opts)
         cmd.extend(self.vcfs)
@@ -245,6 +250,7 @@ def process(args):
                                             regions = args.regions,
                sample = args.sample, vcfs = args.vcfs,
                exclude_filtered = args.exclude_filtered,
+               disallow_partial_fp = args.disallow_partial_fp,
                match_geno = args.match_geno, log_to_file= args.log_to_file, opts = args.vcfcompare_options)
     varsim_tp, varsim_fn, varsim_fp = varsim_comparator.get_tp(), varsim_comparator.get_fn(), varsim_comparator.get_fp()
     varsim_tp = utils.sort_and_compress(varsim_tp)
@@ -376,6 +382,7 @@ if __name__ == "__main__":
     main_parser.add_argument("--regions", help="BED file to restrict analysis [Optional]", required = False, type=str)
     main_parser.add_argument("--sample", metavar = "SAMPLE", help="sample name", required = False, type=str)
     main_parser.add_argument("--exclude_filtered", action = 'store_true', help="only consider variants with PASS or . in FILTER column", required = False)
+    main_parser.add_argument("--disallow_partial_fp", action = 'store_true', help="For a partially-matched false negative variant, output all matching variants as false positive", required = False)
     main_parser.add_argument("--match_geno", action = 'store_true', help="compare genotype in addition to alleles", required = False)
     main_parser.add_argument("--sv_length", type = int, help="length cutoff for SV (only effective for counting, not comparison). For comparison, please add -sv_length to --vcfcompare_options.", required = False, default = 100)
     main_parser.add_argument('--version', action='version', version=utils.get_version())

--- a/src/test/java/com/bina/varsim/tools/evaluation/VCFCompareTest.java
+++ b/src/test/java/com/bina/varsim/tools/evaluation/VCFCompareTest.java
@@ -325,4 +325,14 @@ public class VCFCompareTest {
     //disabled until global matching is implemented
     universalTestMethod("src/test/resources/validationTest/distanceMetricTests/multipleMatchingDistance", new String[]{"-wig", "50","-over","0.7","-output_distance_metric"});
   }
+  /**
+   * complex variant
+   * CAAAA -> CAAG 1/1
+   * is called as 1 DEL + 1 SNV
+   * partial matching disallowed (so that rtg can rescue this case)
+   */
+  @Test
+  @Ignore public void complexVariantNoPartialMatchingTest() throws IOException {
+    universalTestMethod("src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest", new String[]{"-disallow_partial_fp"});
+  }
 }

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/compare.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/compare.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.3
+##reference=/Users/guoy28/projects/varsim/varsim_run/smalltest/ref_renamed.fa
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+1	1	.	CAA	CA	.	.	.	GT	1/1
+1	8	.	A	G	.	.	.	GT	1/1

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/ref.fa
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/ref.fa
@@ -1,0 +1,2 @@
+>1
+CAAAAAAAC

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_FN.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_FN.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.3
+##reference=null
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles. No SVLEN for 0. One SVLEN for each ALT allele.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence.if POS2<=END2, then another sequence is inserted at positive strand;if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion).">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##INFO=<ID=VARIANT_OVERALL_TYPE,Number=1,Type=String,Description="Overall variant type">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN valueshere we changed it to String to allow such behavior.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+1	6	.	AAA	AG	.	PASS	VARIANT_OVERALL_TYPE=Complex;SVLEN=-1	GT	1|1

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_FP.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_FP.vcf
@@ -1,0 +1,25 @@
+##fileformat=VCFv4.3
+##reference=null
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles. No SVLEN for 0. One SVLEN for each ALT allele.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence.if POS2<=END2, then another sequence is inserted at positive strand;if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion).">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##INFO=<ID=VARIANT_OVERALL_TYPE,Number=1,Type=String,Description="Overall variant type">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN valueshere we changed it to String to allow such behavior.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+1	2	.	AA	A	.	.	VARIANT_OVERALL_TYPE=Deletion;SVTYPE=DEL;SVLEN=-1	GT	1|1
+1	8	.	A	G	.	.	VARIANT_OVERALL_TYPE=SNP	GT	1|1

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_TP.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_TP.vcf
@@ -1,0 +1,23 @@
+##fileformat=VCFv4.3
+##reference=null
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles. No SVLEN for 0. One SVLEN for each ALT allele.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence.if POS2<=END2, then another sequence is inserted at positive strand;if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion).">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##INFO=<ID=VARIANT_OVERALL_TYPE,Number=1,Type=String,Description="Overall variant type">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN valueshere we changed it to String to allow such behavior.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_unknown_FP.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_unknown_FP.vcf
@@ -1,0 +1,23 @@
+##fileformat=VCFv4.3
+##reference=null
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles. No SVLEN for 0. One SVLEN for each ALT allele.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence.if POS2<=END2, then another sequence is inserted at positive strand;if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion).">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##INFO=<ID=VARIANT_OVERALL_TYPE,Number=1,Type=String,Description="Overall variant type">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN valueshere we changed it to String to allow such behavior.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_unknown_TP.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/test_unknown_TP.vcf
@@ -1,0 +1,23 @@
+##fileformat=VCFv4.3
+##reference=null
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles. No SVLEN for 0. One SVLEN for each ALT allele.">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence.if POS2<=END2, then another sequence is inserted at positive strand;if POS2>=END2, then reversed sequence is inserted at negative strand (insert with inversion).">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##INFO=<ID=VARIANT_OVERALL_TYPE,Number=1,Type=String,Description="Overall variant type">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.CN is defined as Integer in VCF4.1,4.3, making it impossible to specify multiple CN valueshere we changed it to String to allow such behavior.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test

--- a/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/truth.vcf
+++ b/src/test/resources/validationTest/complexVariantTests/noPartialMatchingTest/truth.vcf
@@ -1,0 +1,23 @@
+##fileformat=VCFv4.3
+##reference=/Users/guoy28/projects/varsim/varsim_run/smalltest/ref_renamed.fa
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=POS2,Number=1,Type=Integer,Description="1-based start position of source sequence">
+##INFO=<ID=END2,Number=1,Type=Integer,Description="1-based end position of source sequence">
+##INFO=<ID=END,Number=1,Type=Integer,Description="1-based end position of variant">
+##INFO=<ID=CHR2,Number=1,Type=String,Description="Chromosome of source sequence">
+##INFO=<ID=ISINV,Number=1,Type=Flag,Description="whether a duplication is inverted">
+##INFO=<ID=TRAID,Number=1,Type=String,Description="translocation ID">
+##INFO=<ID=IMPRECISE_LENGTH,Number=1,Type=Flag,Description="SVLEN is imprecise">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=CN,Number=1,Type=String,Description="Copy number genotype.">
+##ALT=<ID=DEL,Description="Deletion">
+##ALT=<ID=DEL:TRA,Description="Deletion in translocation">
+##ALT=<ID=DUP,Description="Duplication">
+##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
+##ALT=<ID=DUP:ISP,Description="Interspersed duplication">
+##ALT=<ID=DUP:TRA,Description="Duplication in translocation">
+##ALT=<ID=INS,Description="Insertion of novel sequence">
+##ALT=<ID=INV,Description="Inversion">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test
+1	6	.	AAA	AG	.	PASS	.	GT	1|1


### PR DESCRIPTION
- [ ] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [ ] Blocking PRs: ADD HERE IF ANY
* People
  - [ ] Reviewers (>=1): ADD HERE
  - [ ] Merger (>=1): ADD HERE
  - [ ] FYI: ADD HERE IF ANY
- [ ] Release note (if needed)
- [ ] No code copied from outside Bina 
- [ ] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

if a complex variant is compared with multiple variants and is considered as FN, output all matching variants as FP if `--disallow_partial_fp` is used.

This only affects behavior of VarSim, but not RTG or the `augmented*` files.
