### PR TITLE
Faster liftover

### DIFF
--- a/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
@@ -276,7 +276,7 @@ public class VCF2diploid extends VarSimTool {
             log.info("number of variants: " + varList.size());
 
             //VCF is written on a per-chromosome basis
-            writeVCF(referenceSequence, varList, paternalIsVariantAdded,
+            writeVCF(referenceSequence, allSequences, varList, paternalIsVariantAdded,
                     maternalIsVariantAdded, outputPaternal, outputMaternal);
 
             if (outputPaternal) {
@@ -661,7 +661,7 @@ public class VCF2diploid extends VarSimTool {
      * Writes out the vcf record for all variants that have added_variants =
      * true
      */
-    private void writeVCF(final Sequence refSeq, final List<Variant> varList,
+    private void writeVCF(final Sequence refSeq, final SimpleReference reference, final List<Variant> varList,
                           final List<Boolean> paternalAddedVariants,
                           final List<Boolean> maternalAddedVariants,
                           final boolean outputPaternal, final boolean outputMaternal) {
@@ -674,7 +674,6 @@ public class VCF2diploid extends VarSimTool {
             BufferedWriter bw = new BufferedWriter(fw);
 
             // write header
-            SimpleReference reference = new SimpleReference(chrfiles.get(0));
             bw.write(VCFWriter.generateVCFHeader(reference, new ImmutableList.Builder<String>().addAll(idList).build()));
 
             int num_vars = varList.size();

--- a/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
@@ -180,6 +180,11 @@ public class VCF2diploid extends VarSimTool {
         // This is the loop if chromosomes exist in separate files
         SimpleReference allSequences = new SimpleReference(chrfiles);
 
+        //VCF header will be the same within this call
+        List<String> idList = new ArrayList<>();
+        idList.add(id);
+        final String header = VCFWriter.generateVCFHeader(allSequences, new ImmutableList.Builder<String>().addAll(idList).build());
+
         // This is the loop through each chromosome
         for (ChrString chr : allSequences.keySet()) {
             Sequence referenceSequence = allSequences.getSequence(chr);
@@ -276,7 +281,7 @@ public class VCF2diploid extends VarSimTool {
             log.info("number of variants: " + varList.size());
 
             //VCF is written on a per-chromosome basis
-            writeVCF(referenceSequence, allSequences, varList, paternalIsVariantAdded,
+            writeVCF(referenceSequence, header, varList, paternalIsVariantAdded,
                     maternalIsVariantAdded, outputPaternal, outputMaternal);
 
             if (outputPaternal) {
@@ -661,20 +666,18 @@ public class VCF2diploid extends VarSimTool {
      * Writes out the vcf record for all variants that have added_variants =
      * true
      */
-    private void writeVCF(final Sequence refSeq, final SimpleReference reference, final List<Variant> varList,
+    private void writeVCF(final Sequence refSeq, final String header, final List<Variant> varList,
                           final List<Boolean> paternalAddedVariants,
                           final List<Boolean> maternalAddedVariants,
                           final boolean outputPaternal, final boolean outputMaternal) {
         String file_name = refSeq.getName() + "_" + id + ".vcf";
-        List<String> idList = new ArrayList<>();
-        idList.add(id);
         log.info("Writing out the true variants for " + refSeq.getName());
         try {
             FileWriter fw = new FileWriter(new File(outDir, file_name));
             BufferedWriter bw = new BufferedWriter(fw);
 
             // write header
-            bw.write(VCFWriter.generateVCFHeader(reference, new ImmutableList.Builder<String>().addAll(idList).build()));
+            bw.write(header);
 
             int num_vars = varList.size();
 

--- a/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
+++ b/src/main/java/com/bina/varsim/tools/simulation/VCF2diploid.java
@@ -53,6 +53,8 @@ public class VCF2diploid extends VarSimTool {
     private boolean pass = false;
     @Option(name = "-outdir", usage = "Directory to output results in [current directory]")
     File outDir = new File("").getAbsoluteFile();
+    @Option(name = "-no_contig_id", usage = "suppress writing contig IDs into VCF headers (useful when number of contigs is large)")
+    private boolean noContigID = false;
     private Map<ChrString, List<Variant>> variants = new HashMap<>();
 
     /**
@@ -183,7 +185,7 @@ public class VCF2diploid extends VarSimTool {
         //VCF header will be the same within this call
         List<String> idList = new ArrayList<>();
         idList.add(id);
-        final String header = VCFWriter.generateVCFHeader(allSequences, new ImmutableList.Builder<String>().addAll(idList).build());
+        final String header = VCFWriter.generateVCFHeader(noContigID? null : allSequences, new ImmutableList.Builder<String>().addAll(idList).build());
 
         // This is the loop through each chromosome
         for (ChrString chr : allSequences.keySet()) {

--- a/varsim.py
+++ b/varsim.py
@@ -29,11 +29,14 @@ def convertCN(filenames, operation):
     by default the max number will be kept
     the change is in place
     """
+    logger = logging.getLogger(convertCN.__name__)
+    logger.info("convertCN started")
     if operation != "two2one" and operation != "one2two":
         raise ValueError("Only two2one or one2two allowed")
     two2one = operation == "two2one"
     delimiter = re.compile('[/|]')
     for name in filenames:
+        logger.info("processing {}".format(name))
         with versatile_open(name, 'r') as file_fd:
             output = tempfile.NamedTemporaryFile(mode = 'r+w', delete = False)
             for l in file_fd:
@@ -72,6 +75,7 @@ def convertCN(filenames, operation):
             output.close()
             shutil.copyfile(output.name, name)
             os.remove(output.name)
+    logger.info("convertCN done")
     return
 
 
@@ -351,6 +355,7 @@ def varsim_main(reference,
     processes = run_vcfstats(variant_vcfs, out_dir, log_dir)
 
     if not disable_vcf2diploid:
+        logger.info("vcf2diploid started")
         variant_vcfs.reverse()
         vcf2diploid_stdout = open(os.path.join(out_dir, "vcf2diploid.out"), "w")
         vcf2diploid_stderr = open(os.path.join(log_dir, "vcf2diploid.err"), "w")
@@ -382,6 +387,7 @@ def varsim_main(reference,
         concatenate_files(vcfs_to_cat, merged_truth_vcf, header_str="#", simple_cat=False, remove_original=True)
 
         monitor_processes(run_vcfstats([merged_truth_vcf], out_dir, log_dir))
+        logger.info("vcf2diploid done")
 
         if lift_ref:
             lifted_dir = os.path.join(out_dir, "lifted")

--- a/varsim.py
+++ b/varsim.py
@@ -364,7 +364,7 @@ def varsim_main(reference,
         vcf2diploid_command = ["java", utils.JAVA_XMX, "-jar", VARSIMJAR, "vcf2diploid",
                                "-t", sex,
                                "-id", sample_id,
-                               "-chr", os.path.realpath(reference)] + filter_arg_list + vcf_arg_list
+                               "-chr", os.path.realpath(reference)] + filter_arg_list + vcf_arg_list + ["-no_contig_id"]
 
         logger.info("Executing command " + " ".join(vcf2diploid_command))
         subprocess.check_call(vcf2diploid_command, stdout=vcf2diploid_stdout, stderr=vcf2diploid_stderr,


### PR DESCRIPTION
- [ ] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [ ] Blocking PRs: #176 
* People
  - [ ] Reviewers (>=1): ADD HERE
  - [ ] Merger (>=1): ADD HERE
  - [ ] FYI: ADD HERE IF ANY
- [ ] Release note (if needed)
- [ ] No code copied from outside Bina 
- [ ] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

* reuse vcf header in `VCF2Diploid`
* add an option to suppress writing contig names in VCF header, useful when number of contigs is large, e.g. when restricted vcfs are generated for a large number of intervals.
* \>1000x speedup for large number of intervals
