### PR TITLE
Fix boundary issue

### DIFF
--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -336,7 +336,7 @@ def parse_jsons(jsonfile, stats, count_sv = False, count_all = False):
                         print ("error in {}. No {} field".format(jsonfile, err))
                         stats[vt][mt] += 0
 
-def summarize_results(prefix, tp, fn, fp, t, var_types = ['SNP', 'Deletion', 'Insertion', 'Complex'], sv_length = 100, regions = None, bed_either = False):
+def summarize_results(prefix, tp, fn, fp, t, var_types, sv_length = 100, regions = None, bed_either = False):
     '''
     count variants by type and tabulate
     :param augmented_tp:

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -143,22 +143,20 @@ public class VCFCompareResultsParser extends VarSimTool {
     private void countVariants(final StatsNamespace resultClass, final String filename, outputClass outputBlob, BedFile intersector) {
         VCFparser vcfParser = new VCFparser(filename, null, false);
         PrintWriter vcfWriter = null;
-        if (intersector != null) {
-            try {
-                if (resultClass == StatsNamespace.TP) {
-                    vcfWriter = tp_WRITER.getWriter(outPrefix);
-                } else if (resultClass == StatsNamespace.T) {
-                    vcfWriter = t_WRITER.getWriter(outPrefix);
-                } else if (resultClass == StatsNamespace.FN) {
-                    vcfWriter = fn_WRITER.getWriter(outPrefix);
-                } else if (resultClass == StatsNamespace.FP) {
-                    vcfWriter = fp_WRITER.getWriter(outPrefix);
-                } else {
-                    throw new IllegalArgumentException();
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+        try {
+            if (resultClass == StatsNamespace.TP) {
+                vcfWriter = tp_WRITER.getWriter(outPrefix);
+            } else if (resultClass == StatsNamespace.T) {
+                vcfWriter = t_WRITER.getWriter(outPrefix);
+            } else if (resultClass == StatsNamespace.FN) {
+                vcfWriter = fn_WRITER.getWriter(outPrefix);
+            } else if (resultClass == StatsNamespace.FP) {
+                vcfWriter = fp_WRITER.getWriter(outPrefix);
+            } else {
+                throw new IllegalArgumentException();
             }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
         vcfWriter.write(new VCFparser(filename, null, false).extractHeader());
         while (vcfParser.hasMoreInput()) {

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -187,6 +187,7 @@ public class VCFCompareResultsParser extends VarSimTool {
                 throw new IllegalArgumentException();
             }
         }
+        vcfWriter.close();
     }
 }
 class CompareParams {

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -50,6 +50,9 @@ public class VCFCompareResultsParser extends VarSimTool {
     @Option(name = "-fp", usage = "False positive VCF file", metaVar = "file", required = true)
     String fpVcfFilename;
 
+    @Option(name = "-t", usage = "truth VCF file", metaVar = "file", required = true)
+    String tVcfFilename;
+
     @Option(name = "-prefix", usage = "prefix for output", metaVar = "string", required = true)
     String outPrefix = null;
 
@@ -94,6 +97,7 @@ public class VCFCompareResultsParser extends VarSimTool {
         countVariants(StatsNamespace.TP, tpVcfFilename, outputBlob, intersector);
         countVariants(StatsNamespace.FP, fpVcfFilename, outputBlob, intersector);
         countVariants(StatsNamespace.FN, fnVcfFilename, outputBlob, intersector);
+        countVariants(StatsNamespace.T, tVcfFilename, outputBlob, intersector);
 
         try(
                 PrintWriter jsonWriter = JSON_WRITER.getWriter(outPrefix);) {
@@ -147,6 +151,8 @@ public class VCFCompareResultsParser extends VarSimTool {
                     vcfWriter = t_WRITER.getWriter(outPrefix);
                 } else if (resultClass == StatsNamespace.FN) {
                     vcfWriter = fn_WRITER.getWriter(outPrefix);
+                } else if (resultClass == StatsNamespace.FP) {
+                    vcfWriter = fp_WRITER.getWriter(outPrefix);
                 } else {
                     throw new IllegalArgumentException();
                 }
@@ -175,6 +181,8 @@ public class VCFCompareResultsParser extends VarSimTool {
                 outputBlob.getNumberOfTrueCorrect().incT(currentVariant.getType(), currentVariant.maxLen());
             } else if (resultClass == StatsNamespace.FN) {
                 outputBlob.getNumberOfTrueCorrect().incT(currentVariant.getType(), currentVariant.maxLen());
+            } else if (resultClass == StatsNamespace.T) {
+              //do nothing assuming FN+TP=T
             } else {
                 throw new IllegalArgumentException();
             }

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -100,7 +100,7 @@ public class VCFCompareResultsParser extends VarSimTool {
         // store true variants as canonical ones, but remember original form
         while (fpVcfParser.hasMoreInput()) {
             Variant currentVariant = fpVcfParser.parseLine();
-            if (intersector != null) {
+            if (intersector != null && currentVariant != null) {
                 if (!intersector.containsEndpoints(currentVariant.getChr(),
                         currentVariant.getGenotypeUnionAlternativeInterval(), bedEither)) {
                   currentVariant = null;
@@ -114,7 +114,7 @@ public class VCFCompareResultsParser extends VarSimTool {
         }
         while (tpVcfParser.hasMoreInput()) {
             Variant currentVariant = tpVcfParser.parseLine();
-            if (intersector != null) {
+            if (intersector != null && currentVariant != null) {
                 if (!intersector.containsEndpoints(currentVariant.getChr(),
                         currentVariant.getGenotypeUnionAlternativeInterval(), bedEither)) {
                     currentVariant = null;
@@ -129,7 +129,7 @@ public class VCFCompareResultsParser extends VarSimTool {
         }
         while (fnVcfParser.hasMoreInput()) {
             Variant currentVariant = fnVcfParser.parseLine();
-            if (intersector != null) {
+            if (intersector != null && currentVariant != null) {
                 if (!intersector.containsEndpoints(currentVariant.getChr(),
                         currentVariant.getGenotypeUnionAlternativeInterval(), bedEither)) {
                     currentVariant = null;

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -160,7 +160,7 @@ public class VCFCompareResultsParser extends VarSimTool {
                 e.printStackTrace();
             }
         }
-        vcfWriter.write(VCFWriter.extractHeader(filename));
+        vcfWriter.write(new VCFparser(filename, null, false).extractHeader());
         while (vcfParser.hasMoreInput()) {
             Variant currentVariant = vcfParser.parseLine();
             if (intersector != null && currentVariant != null) {

--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFCompareResultsParser.java
@@ -166,7 +166,7 @@ public class VCFCompareResultsParser extends VarSimTool {
             if (intersector != null && currentVariant != null) {
                 if (intersector.containsEndpoints(currentVariant.getChr(),
                         currentVariant.getGenotypeUnionAlternativeInterval())) {
-                    vcfWriter.write(currentVariant.toString());
+                    vcfWriter.write(currentVariant.toString() + "\n");
                 } else {
                     currentVariant = null;
                 }

--- a/src/main/java/com/bina/varsim/types/BedFile.java
+++ b/src/main/java/com/bina/varsim/types/BedFile.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 public class BedFile {
     String _filename; // file name of the BED file
     chrSearchTree<SimpleInterval1D> bedST; // the interval search tree for bed file
+    boolean bedEither = false;
 
     /**
      * Reads the BED file into a search tree
@@ -36,6 +37,17 @@ public class BedFile {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * reads a BED file into a search tree
+     *
+     * @param filename BED file
+     * @param bedEither use either end to check overlap if true
+     */
+    public BedFile(final String filename, final boolean bedEither) {
+        this(filename);
+        this.bedEither = bedEither;
     }
 
     /**
@@ -114,6 +126,13 @@ public class BedFile {
                         bedST.contains(chr, new SimpleInterval1D(interval.getRight(), interval.getRight()));
             }
         }
+    }
+
+    /**
+     * same as containsEndpoints, but use either from constructor
+     */
+    public boolean containsEndpoints(ChrString chr, SimpleInterval1D interval) {
+        return containsEndpoints(chr, interval, bedEither);
     }
 
 

--- a/src/main/java/com/bina/varsim/types/ComparisonResultWriter.java
+++ b/src/main/java/com/bina/varsim/types/ComparisonResultWriter.java
@@ -15,7 +15,10 @@ public enum ComparisonResultWriter {
   FP_WRITER("_FP.vcf", FileType.VCF),
   UNKNOWN_FP_WRITER("_unknown_FP.vcf", FileType.VCF),
   FN_WRITER("_FN.vcf", FileType.VCF),
-  JSON_WRITER("_report.json", FileType.JSON);
+  JSON_WRITER("_report.json", FileType.JSON),
+  tp_WRITER("_tp.vcf", FileType.VCF),
+  t_WRITER("_t.vcf", FileType.VCF),
+  fn_WRITER("_fn.vcf", FileType.VCF);
 
   private static final String encoding = "UTF-8";
   private FileType fileType;

--- a/src/main/java/com/bina/varsim/types/ComparisonResultWriter.java
+++ b/src/main/java/com/bina/varsim/types/ComparisonResultWriter.java
@@ -18,7 +18,8 @@ public enum ComparisonResultWriter {
   JSON_WRITER("_report.json", FileType.JSON),
   tp_WRITER("_tp.vcf", FileType.VCF),
   t_WRITER("_t.vcf", FileType.VCF),
-  fn_WRITER("_fn.vcf", FileType.VCF);
+  fn_WRITER("_fn.vcf", FileType.VCF),
+  fp_WRITER("_fp.vcf", FileType.VCF);
 
   private static final String encoding = "UTF-8";
   private FileType fileType;

--- a/src/main/java/com/bina/varsim/util/VCFWriter.java
+++ b/src/main/java/com/bina/varsim/util/VCFWriter.java
@@ -73,27 +73,4 @@ public class VCFWriter {
             (sampleNames.isEmpty() ? "" : "\t") + joiner.toString() + "\n");
     return VCFHeader.toString();
   }
-
-  /**
-   * extract header from a VCF
-   * @param filename
-   */
-  public static String extractHeader(final String filename) {
-    File file = new File(filename);
-    StringBuilder stringBuilder = new StringBuilder();
-    try (BufferedReader br = new BufferedReader(new FileReader(file))) {
-      String l;
-      while ((l = br.readLine()) != null) {
-        if(l.startsWith("#")) {
-          stringBuilder.append(l);
-          stringBuilder.append("\n");
-        } else {
-          break;
-        }
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return stringBuilder.toString();
-  }
 }

--- a/src/main/java/com/bina/varsim/util/VCFWriter.java
+++ b/src/main/java/com/bina/varsim/util/VCFWriter.java
@@ -86,6 +86,7 @@ public class VCFWriter {
       while ((l = br.readLine()) != null) {
         if(l.startsWith("#")) {
           stringBuilder.append(l);
+          stringBuilder.append("\n");
         } else {
           break;
         }

--- a/src/main/java/com/bina/varsim/util/VCFWriter.java
+++ b/src/main/java/com/bina/varsim/util/VCFWriter.java
@@ -3,6 +3,9 @@ package com.bina.varsim.util;
 import com.bina.varsim.types.ChrString;
 import com.google.common.collect.ImmutableList;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.util.StringJoiner;
 import java.util.logging.Logger;
 
@@ -69,5 +72,27 @@ public class VCFWriter {
     VCFHeader.append("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT" +
             (sampleNames.isEmpty() ? "" : "\t") + joiner.toString() + "\n");
     return VCFHeader.toString();
+  }
+
+  /**
+   * extract header from a VCF
+   * @param filename
+   */
+  public static String extractHeader(final String filename) {
+    File file = new File(filename);
+    StringBuilder stringBuilder = new StringBuilder();
+    try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+      String l;
+      while ((l = br.readLine()) != null) {
+        if(l.startsWith("#")) {
+          stringBuilder.append(l);
+        } else {
+          break;
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return stringBuilder.toString();
   }
 }

--- a/src/main/java/com/bina/varsim/util/VCFparser.java
+++ b/src/main/java/com/bina/varsim/util/VCFparser.java
@@ -706,6 +706,7 @@ public class VCFparser extends GzFileParser<Variant> {
         while (line != null && line.startsWith("#")) {
             stringBuilder.append(line);
             stringBuilder.append("\n");
+            readLine();
         }
         try {
             this.bufferedReader.close(); //right now use this naive method to prevent more reading

--- a/src/main/java/com/bina/varsim/util/VCFparser.java
+++ b/src/main/java/com/bina/varsim/util/VCFparser.java
@@ -696,6 +696,25 @@ public class VCFparser extends GzFileParser<Variant> {
       }
     }
 
+    /**
+     * extract header from a VCF
+     * must be run before parseLine, otherwise may return nothing
+     */
+    public String extractHeader() {
+        readLine();
+        StringBuilder stringBuilder = new StringBuilder();
+        while (line != null && line.startsWith("#")) {
+            stringBuilder.append(line);
+            stringBuilder.append("\n");
+        }
+        try {
+            this.bufferedReader.close(); //right now use this naive method to prevent more reading
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return stringBuilder.toString();
+    }
+
     public Variant parseLine() {
         /*
         TODO: line reading should be handled in a loop calling


### PR DESCRIPTION
# Summary

* Some TP variants might be ignored due to shifting beyond target interval after representation/normalization
* now varsim will perform region-less comparison first, followed by region-filtering of Truth/TP/FP/FN. This of course assumes that some variants can show up outside of target region.