### PR TITLE
fix vcf header extraction

### DIFF
--- a/src/main/java/com/bina/varsim/util/VCFparser.java
+++ b/src/main/java/com/bina/varsim/util/VCFparser.java
@@ -701,17 +701,11 @@ public class VCFparser extends GzFileParser<Variant> {
      * must be run before parseLine, otherwise may return nothing
      */
     public String extractHeader() {
-        readLine();
         StringBuilder stringBuilder = new StringBuilder();
         while (line != null && line.startsWith("#")) {
             stringBuilder.append(line);
             stringBuilder.append("\n");
             readLine();
-        }
-        try {
-            this.bufferedReader.close(); //right now use this naive method to prevent more reading
-        } catch (Exception e) {
-            e.printStackTrace();
         }
         return stringBuilder.toString();
     }

--- a/src/main/java/com/bina/varsim/util/VCFparser.java
+++ b/src/main/java/com/bina/varsim/util/VCFparser.java
@@ -707,6 +707,16 @@ public class VCFparser extends GzFileParser<Variant> {
             stringBuilder.append("\n");
             readLine();
         }
+
+        //readLine automatically close filehandle when no more lines
+        if (line != null) {
+            try {
+                this.bufferedReader.close(); //right now use this naive method to prevent more reading
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
         return stringBuilder.toString();
     }
 


### PR DESCRIPTION
- [ ] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [ ] Blocking PRs: ADD HERE IF ANY
* People
  - [ ] Reviewers (>=1): ADD HERE
  - [ ] Merger (>=1): ADD HERE
  - [ ] FYI: ADD HERE IF ANY
- [ ] Release note (if needed)
- [ ] No code copied from outside Bina 
- [ ] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

* remove `readLine` because it has been run once when file is open
* close filehandle only when there are more lines (otherwise it will have been closed by `readLine`

