### PR TITLE
More robust af calc

### DIFF
--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -316,7 +316,6 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
     """Try to pair up each false call in a file (augmented_file) with a variant in the other files provided in a list (files_to_pair_with) to create an annotated version of the first file.
     By default the the first variant in the list is provided to get an AF, the 2nd to determine the simulated variant (for false positives) and the 3rd to determine if a false positive is
     a pure false positive (not simulated) or not (wrong genotype)"""
-    out_file = open("out.out", "w")
     files_to_pair_with_clean = []
     for item in files_to_pair_with:
         files_to_pair_with_clean.append(utils.make_clean_vcf(item, out_dir))
@@ -370,14 +369,12 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
 
                     if i == 0:
                         if equivalent_variant:
-                            out_file.write(' '.join(equivalent_variant)+'\n')
                             AO_RO_DP = {"AO": None, "RO": None, "DP": None}
 
                             for entry in AO_RO_DP:
                                 try:
                                     #Loop backwards through fields to preferentially extract AO and RO from SAMPLE over INFO
                                     for field in equivalent_variant[::-1]:
-                                        out_file.write(field + '\n')
                                         found = re.search("['\t', ':']{}['\t', ':']".format(entry), field)
                                         if found:
                                             field_split = field.split(':')
@@ -398,7 +395,6 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                                 info = "N/A;"
 
                             info += "N/A;" if not AO_RO_DP["DP"] else str(AO_RO_DP["DP"]) + ';'
-                            out_file.write(info+'\n')
                     elif i == 1:
                         if equivalent_variant:
                             info += equivalent_variant[0]+'_'+equivalent_variant[1]+'_'+equivalent_variant[3]+'_'+equivalent_variant[4]+'_'+equivalent_variant[-1] + ";"
@@ -425,7 +421,6 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
         if item and os.path.isfile(item):
             os.remove(item)
             os.remove(item+".tbi")
-    out_file.close()
 
 def print_stats(stats):
     '''

--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -369,9 +369,8 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                             shutil.rmtree(vcfeval_prefix)
 
                     if i == 0:
+                        AO_RO_DP = {"AO": None, "RO": None, "DP": None}
                         if equivalent_variant:
-                            AO_RO_DP = {"AO": None, "RO": None, "DP": None}
-
                             for entry in AO_RO_DP:
                                 try:
                                     #Loop backwards through fields to preferentially extract AO and RO from SAMPLE over INFO
@@ -390,12 +389,12 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                                             break
                                 except:
                                     pass
-                            if AO_RO_DP["AO"] and AO_RO_DP["RO"]:
-                                info = str(float(AO_RO_DP["AO"])/(AO_RO_DP["AO"]+AO_RO_DP["RO"])) + ';'
-                            else:
-                                info = "N/A;"
+                        if AO_RO_DP["AO"] and AO_RO_DP["RO"]:
+                            info = str(float(AO_RO_DP["AO"])/(AO_RO_DP["AO"]+AO_RO_DP["RO"])) + ';'
+                        else:
+                            info = "N/A;"
 
-                            info += "N/A;" if not AO_RO_DP["DP"] else str(AO_RO_DP["DP"]) + ';'
+                        info += "N/A;" if not AO_RO_DP["DP"] else str(AO_RO_DP["DP"]) + ';'
                     elif i == 1:
                         if equivalent_variant:
                             info += equivalent_variant[0]+'_'+equivalent_variant[1]+'_'+equivalent_variant[3]+'_'+equivalent_variant[4]+'_'+equivalent_variant[-1] + ";"

--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -377,17 +377,31 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                         # gatk4 format
                         if AO_RO_DP_AD["AD"]:
                             AD_split = AO_RO_DP_AD["AD"].split(',')
-                            AO = int(AD_split[1])
+                            AO = list(map(int, AD_split[1:]))
                             RO = int(AD_split[0])
-                            info += "0.0;" if AO+RO == 0 else str(float(AO)/(AO+RO)) + ';'
+                            for i, item in enumerate(AO):
+                                comma = ',' if i < len(AO)-1 else ''
+                                if item+RO == 0:
+                                    info += "0.0" + comma
+
+                                else:
+                                    info += str(float(item)/(item+RO)) + comma
                         #freebayes
                         elif AO_RO_DP_AD["AO"] and AO_RO_DP_AD["RO"]:
-                            denominator = int(AO_RO_DP_AD["AO"].split(',')[0])+int(AO_RO_DP_AD["RO"].split(',')[0])
-                            info += "0.0;" if denominator == 0 else str(float(AO_RO_DP_AD["AO"].split(',')[0])/denominator) + ';'
-                        else:
-                            info += "N/A;"
+                            for i, item in enumerate(AO_RO_DP_AD["AO"].split(',')):
+                                comma = ',' if i < len(AO_RO_DP_AD["AO"].split(','))-1 else ''
+                                denominator = int(item)+int(AO_RO_DP_AD["RO"])
+                                if denominator == 0:
+                                    info += "0.0" + comma
 
-                        info += "N/A;" if not AO_RO_DP_AD["DP"] else str(AO_RO_DP_AD["DP"]) + ';'
+                                else:
+                                    info += str(float(item)/denominator) + comma
+                        else:
+                            info += "N/A"
+
+                        info += ';'
+                        info += "N/A" if not AO_RO_DP_AD["DP"] else str(AO_RO_DP_AD["DP"])
+                        info += ';'
                     elif i == 1:
                         if equivalent_variant:
                             info += equivalent_variant[0]+'_'+equivalent_variant[1]+'_'+equivalent_variant[3]+'_'+equivalent_variant[4]+'_'+equivalent_variant[-1] + ";"

--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -341,6 +341,7 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                 single_var_file = utils.sort_and_compress(single_var_file)
 
                 single_var_chr = line_split[0]
+                info = ''
 
                 for i, item in enumerate(files_to_pair_with_clean):
 

--- a/utils.py
+++ b/utils.py
@@ -253,6 +253,22 @@ def write_vcf(lines, vcf):
     return vcf
 
 
+def write_filtered_vcf(vcf, chrm, out_vcf):
+
+    content = []
+
+    with versatile_open(vcf, "r") as vcf_handle:
+
+        for line in vcf_handle.readlines():
+            line_strip = line.strip()
+            line_split = line_strip.split()
+
+            if line_split[0][0] == "#" or line_split[0] == chrm:
+                content.append(line_strip)
+
+    return write_vcf(content, out_vcf)
+
+
 def get_equivalent_variant(variant, vcf):
     """Return the variant in a vcf closest to a variant"""
 
@@ -304,7 +320,9 @@ def make_clean_vcf(vcf, path=None):
                 continue
             else:
                 GT = "0/1" if line_split[-1] == "./." else line_split[-1]
-                clean_vcf_handle.write('\t'.join([line_split[0], line_split[1], ".", line_split[3], line_split[4], ".", ".", ".", line_split[8], GT]) + '\n')
+                info_entries = [line_split[7].split('=')[0] for x in line_split[7].split(';')]
+                info = "." if len(set(info_entries)) < len(info_entries) else line_split[7]
+                clean_vcf_handle.write('\t'.join([line_split[0], line_split[1], ".", line_split[3], line_split[4], ".", ".", info, line_split[8], GT]) + '\n')
 
     clean_vcf_handle.close()
 

--- a/utils.py
+++ b/utils.py
@@ -320,7 +320,7 @@ def make_clean_vcf(vcf, path=None):
                 continue
             else:
                 GT = "0/1" if line_split[-1] == "./." else line_split[-1]
-                info_entries = [line_split[7].split('=')[0] for x in line_split[7].split(';')]
+                info_entries = [x.split('=')[0] for x in line_split[7].split(';')]
                 info = "." if len(set(info_entries)) < len(info_entries) else line_split[7]
                 clean_vcf_handle.write('\t'.join([line_split[0], line_split[1], ".", line_split[3], line_split[4], ".", ".", info, line_split[8], GT]) + '\n')
 

--- a/utils.py
+++ b/utils.py
@@ -259,7 +259,7 @@ def write_filtered_vcf(vcf, chrm, out_vcf):
 
     with versatile_open(vcf, "r") as vcf_handle:
 
-        for line in vcf_handle.readlines():
+        for line in vcf_handle:
             line_strip = line.strip()
             line_split = line_strip.split()
 
@@ -311,7 +311,7 @@ def make_clean_vcf(vcf, path=None):
     clean_vcf_handle = open(clean_vcf, "w")
 
     with versatile_open(vcf, "r") as vcf_handle:
-        for line in vcf_handle.readlines():
+        for line in vcf_handle:
             line_strip = line.strip()
             line_split = line_strip.split()
 

--- a/utils.py
+++ b/utils.py
@@ -254,6 +254,7 @@ def write_vcf(lines, vcf):
 
 
 def write_filtered_vcf(vcf, chrm, out_vcf):
+    """Extract from a vcf file only variants that are located in a specified chromosome"""
 
     content = []
 

--- a/utils.py
+++ b/utils.py
@@ -277,7 +277,7 @@ def get_equivalent_variant(variant, vcf):
     with versatile_open(vcf, "r") as vcf_handle:
         min_dist = 100
 
-        for line in vcf_handle.readlines():
+        for line in vcf_handle:
             line_split = str(line).strip().split()
 
             if line_split[0][0] == "#":


### PR DESCRIPTION
# Summary

- The calculation of AF for annotated files has been made more robust to different vcf file formats. 

- "Coverage" is now also added to annotated files using the DP field

- Pairwise vcf comparisons for single variants has been sped up by restricting the vcf being searched to variants that are on the same chromosome as the single variant  
