### PR TITLE
More robust annotation

### DIFF
--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -367,6 +367,11 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                                          opts = vcfeval_options, java = java)
 
                         equivalent_variant = utils.get_equivalent_variant(line_split, vcfeval_comparator.get_tp())
+
+                        #if not equivalent_variant, check for matching alt and ref at the same position. Example of when this could be applicable is a 0/0 call
+                        if not equivalent_variant:
+                            equivalent_variant = utils.get_matching_alt_ref(line_split, filtered_true_vcf)
+
                         #clean up
                         if os.path.exists(vcfeval_prefix):
                             LOGGER.warn('{0} exists, removing ...'.format(vcfeval_prefix))

--- a/compare_vcf.py
+++ b/compare_vcf.py
@@ -349,7 +349,7 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
 
                 for i, item in enumerate(files_to_pair_with_clean):
 
-                    equivalent_variant = None
+                    nonmatching_gt_variant = None
 
                     if item:
                         vcfeval_prefix = os.path.join(out_dir, 'vcfeval_compare_results_annotate')
@@ -366,11 +366,11 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                                          log_to_file= log_to_file,
                                          opts = vcfeval_options, java = java)
 
-                        equivalent_variant = utils.get_equivalent_variant(line_split, vcfeval_comparator.get_tp())
+                        nonmatching_gt_variant = utils.get_closest_variant(line_split, vcfeval_comparator.get_tp())
 
-                        #if not equivalent_variant, check for matching alt and ref at the same position. Example of when this could be applicable is a 0/0 call
-                        if not equivalent_variant:
-                            equivalent_variant = utils.get_matching_alt_ref(line_split, filtered_true_vcf)
+                        #if not nonmatching_gt_variant, check for matching alt and ref at the same position. Example of when this could be applicable is a 0/0 call when vcfeval will not pair up variants at the same locus with the same alt and ref even with match_geno=False
+                        if not nonmatching_gt_variant:
+                            nonmatching_gt_variant = utils.get_matching_alt_ref(line_split, filtered_true_vcf)
 
                         #clean up
                         if os.path.exists(vcfeval_prefix):
@@ -379,9 +379,9 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
 
                     if i == 0:
                         AO_RO_DP_AD = {"AO": None, "RO": None, "DP": None, "AD": None}
-                        if equivalent_variant:
+                        if nonmatching_gt_variant:
                             for entry in AO_RO_DP_AD:
-                                AO_RO_DP_AD[entry] = utils.get_info(equivalent_variant, entry)
+                                AO_RO_DP_AD[entry] = utils.get_info(nonmatching_gt_variant, entry)
 
                         # gatk4 format
                         if AO_RO_DP_AD["AD"]:
@@ -412,13 +412,13 @@ def match_false(augmented_file, files_to_pair_with, out_dir, sample, log_to_file
                         info += "N/A" if not AO_RO_DP_AD["DP"] else str(AO_RO_DP_AD["DP"])
                         info += ';'
                     elif i == 1:
-                        if equivalent_variant:
-                            info += equivalent_variant[0]+'_'+equivalent_variant[1]+'_'+equivalent_variant[3]+'_'+equivalent_variant[4]+'_'+equivalent_variant[-1] + ";"
+                        if nonmatching_gt_variant:
+                            info += nonmatching_gt_variant[0]+'_'+nonmatching_gt_variant[1]+'_'+nonmatching_gt_variant[3]+'_'+nonmatching_gt_variant[4]+'_'+nonmatching_gt_variant[-1] + ";"
                         else:
                             info += "N/A;"
 
                     elif i == 2:
-                        info += "pure;" if not equivalent_variant else "not;"
+                        info += "pure;" if not nonmatching_gt_variant else "not;"
 
                 line_split[6] = info
                 annotated_content.append('\t'.join(line_split))

--- a/utils.py
+++ b/utils.py
@@ -271,10 +271,10 @@ def write_filtered_vcf(vcf, chrm, out_vcf):
     return write_vcf(content, out_vcf)
 
 
-def get_equivalent_variant(variant, vcf):
+def get_closest_variant(variant, vcf):
     """Return the variant in a vcf closest to a variant"""
 
-    equivalent_variant = None
+    closest_variant = None
 
     with versatile_open(vcf, "r") as vcf_handle:
         min_dist = 100
@@ -290,9 +290,9 @@ def get_equivalent_variant(variant, vcf):
 
                 if dist < min_dist:
                     min_dist = dist
-                    equivalent_variant = line_split[:]
+                    closest_variant = line_split[:]
 
-    return equivalent_variant
+    return closest_variant
 
 
 def get_matching_alt_ref(variant, vcf):

--- a/utils.py
+++ b/utils.py
@@ -295,6 +295,25 @@ def get_equivalent_variant(variant, vcf):
     return equivalent_variant
 
 
+def get_matching_alt_ref(variant, vcf):
+    """Return the variant in a vcf at the same position with matching alt and ref"""
+
+    matching_alt_ref = None
+
+    with versatile_open(vcf, "r") as vcf_handle:
+        for line in vcf_handle:
+            line_split = str(line).strip().split()
+
+            if line_split[0][0] == "#":
+                continue
+
+            if variant[0] == line_split[0] and variant[1] == line_split[1] and variant[3] == line_split[3] and variant[4] == line_split[4]:
+                matching_alt_ref = line_split[:]
+                break
+
+    return matching_alt_ref
+
+
 def get_info(var, entry):
     """Return a value for a user selected field in a line from a vcf (provided as a list split by whitespace)"""
 


### PR DESCRIPTION

# Summary

In compare_vcf.py in def match_false, if an equivalent variant isn't found using vcfeval, try to match based on locus, alt and ref. This is useful for example when a variants genotype is 0/0 due to a filter
