### PR TITLE
fix ART download URL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,8 @@ ART_DIR=${OPT_DIR}/ART
 if [[ ! -d ${ART_DIR} ]]; then
     mkdir -p ${ART_DIR}
     pushd ${ART_DIR}
-    wget --no-check-certificate -O- http://www.niehs.nih.gov/research/resources/assets/docs/artbinvanillaicecream031114linux64tgz.tgz | tar xfz -
+    wget --no-check-certificate -O- https://github.com/bioinform/varsim/files/4156868/art_bin_VanillaIceCream.zip > art_bin_VanillaIceCream.zip
+    unzip art_bin_VanillaIceCream.zip && rm -f art_bin_VanillaIceCream.zip
     popd
 fi
 


### PR DESCRIPTION
- [ ] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [ ] Blocking PRs: ADD HERE IF ANY
* People
  - [ ] Reviewers (>=1): ADD HERE
  - [ ] Merger (>=1): ADD HERE
  - [ ] FYI: ADD HERE IF ANY
- [ ] Release note (if needed)
- [ ] No code copied from outside Bina 
- [ ] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

The link to ART binary hosted on NIH server does not work on some internal networks. Replace it with a github link.