### PR TITLE
fix 0bp length validation bug

### DIFF
--- a/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
+++ b/src/main/java/com/bina/varsim/tools/evaluation/VCFcompare.java
@@ -1155,7 +1155,8 @@ public class VCFcompare extends VarSimTool {
                 //will be carried out on a per-variant basis. An original variant will
                 //be considered a match only if the sum of lengths of all its VALIDATED
                 //canonicalized variants is larger than overlapRatio * totalLength
-                if (validatedLength >= (overlapRatio * totalLength)) {
+                // there are cases where both validatedLength and totalLength are zeros
+                if (validatedLength > 0 && (validatedLength >= (overlapRatio * totalLength))) {
                     // validated
                     outputBlob.getNumberOfTrueCorrect().incTP(var.getType(), var.maxLen());
                     validator.inc(StatsNamespace.TP, var.getType(), var.maxLen());


### PR DESCRIPTION
- [ ] [RES-XXXX](https://binatechnologies.atlassian.net/browse/RES-XXXX)
- [ ] Blocking PRs: ADD HERE IF ANY
* People
  - [ ] Reviewers (>=1): ADD HERE
  - [ ] Merger (>=1): ADD HERE
  - [ ] FYI: ADD HERE IF ANY
- [ ] Release note (if needed)
- [ ] No code copied from outside Bina 
- [ ] Tests (Unit, Workflow, ITL & Gherkin) are passing
- [ ] PR labels, milestones & assignees

# Summary

Fix cases where both validated length and variant length are zeros.
